### PR TITLE
Update legion.rdf

### DIFF
--- a/RDFs/legion.rdf
+++ b/RDFs/legion.rdf
@@ -384,7 +384,7 @@
   <schema:member rdf:resource="Lemie_Alessandrini"/>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Legion"/>
 </rdf:Description>
-  
+
 <rdf:Description rdf:about="Raguel">
   <schema:name xml:lang="ja">第5飛空艇団ラグエル</schema:name>
   <schema:name xml:lang="en">5th Gunship Brigade Raguel</schema:name>

--- a/RDFs/legion.rdf
+++ b/RDFs/legion.rdf
@@ -72,6 +72,8 @@
   <schema:member rdf:resource="Hasebe_Touka"/>
   <schema:member rdf:resource="Aoki_Kaho"/>
   <schema:member rdf:resource="Takegoshi_Chihana"/>
+  <schema:member rdf:resource="Hayashi_Kaoru"/>
+  <schema:member rdf:resource="Niinomi_Nodoka"/>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Legion"/>
 </rdf:Description>
 
@@ -368,6 +370,21 @@
 
 <!-- 聖メルクリウスインターナショナルスクール -->
 
+<rdf:Description rdf:about="Michael">
+  <schema:name xml:lang="ja">第1飛空艇団ミカエル</schema:name>
+  <schema:name xml:lang="en">1st Gunship Brigade Michael</schema:name>
+  <!-- <schema:alternateName xml:lang="ja"></schema:alternateName> -->
+  <!-- <schema:alternateName xml:lang="en"></schema:alternateName> -->
+  <lily:disbanded rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</lily:disbanded>
+  <!-- <lily:legionGrade rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:legionGrade> -->
+  <!-- <lily:numberOfMembers rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:numberOfMembers> -->
+  <schema:member rdf:resource="Altea_Alessandrini"/>
+  <schema:member rdf:resource="Louloudis_Bromstedt"/>
+  <schema:member rdf:resource="Chemir_Friedheim"/>
+  <schema:member rdf:resource="Lemie_Alessandrini"/>
+  <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Legion"/>
+</rdf:Description>
+  
 <rdf:Description rdf:about="Raguel">
   <schema:name xml:lang="ja">第5飛空艇団ラグエル</schema:name>
   <schema:name xml:lang="en">5th Gunship Brigade Raguel</schema:name>
@@ -477,7 +494,7 @@
   <!-- <schema:alternateName xml:lang="ja"></schema:alternateName> -->
   <!-- <schema:alternateName xml:lang="en"></schema:alternateName> -->
   <lily:disbanded rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</lily:disbanded>
-  <!-- <lily:legionGrade rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:legionGrade> -->
+  <lily:legionGrade rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SS</lily:legionGrade>
   <!-- <lily:numberOfMembers rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:numberOfMembers> -->
   <schema:member rdf:resource="Miyairi_Fubuki"/>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Legion"/>


### PR DESCRIPTION
第1飛空艇団ミカエルを追加。アールヴヘイム（初代）のメンバーに林薫・新家和香を追加。ブローズグハッダの格付（SS）を追加。