### PR TITLE
吉田鳳蝶を追加。LGヘルフィヨトゥルを追加。

### DIFF
--- a/RDFs/legion.rdf
+++ b/RDFs/legion.rdf
@@ -254,6 +254,19 @@
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Legion"/>
 </rdf:Description>
 
+<rdf:Description rdf:about="Herfjotur">
+  <schema:name xml:lang="ja">ヘルフィヨトゥル</schema:name>
+  <schema:name xml:lang="en">Herfjötur</schema:name>
+  <!-- <schema:alternateName xml:lang="ja"></schema:alternateName> -->
+  <!-- <schema:alternateName xml:lang="en"></schema:alternateName> -->
+  <lily:disbanded rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</lily:disbanded>
+  <lily:legionGrade rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SS</lily:legionGrade>
+  <!-- <lily:numberOfMembers rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:numberOfMembers> -->
+  <schema:member rdf:resource="Yoshida_Ageha"/><!-- 隊長 -->
+  <!-- <schema:member rdf:resource=""/> -->
+  <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Legion"/>
+</rdf:Description>
+
 <!-- エレンスゲ女学園 -->
 
 <rdf:Description rdf:about="Hervarar">

--- a/RDFs/lily_yurigaoka.rdf
+++ b/RDFs/lily_yurigaoka.rdf
@@ -4566,7 +4566,7 @@
   <lily:position rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BZ</lily:position>
   <!-- <lily:pastLegion rdf:resource=""/> -->
   <!-- <lily:taskforce rdf:resource=""/> -->
-  <!-- <lily:schutzengel rdf:resource=""/> -->
+  <lily:schutzengel rdf:resource="Yoshida_Ageha"/>
   <!-- <lily:pastSchutzengel rdf:resource=""/> -->
   <!-- <lily:schild rdf:resource=""/> -->
   <!-- <lily:pastSchild rdf:resource=""/> -->
@@ -6973,6 +6973,80 @@
   <!-- </lily:cast> -->
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
 </rdf:Description>
+
+
+<!-- LGヘルフィヨトゥル -->
+
+<rdf:Description rdf:about="Yoshida_Ageha">
+  <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">吉田鳳蝶</rdfs:label>
+  <schema:familyName xml:lang="ja">吉田</schema:familyName>
+  <schema:familyName xml:lang="en">Yoshida</schema:familyName>
+  <lily:familyNameKana xml:lang="ja">よしだ</lily:familyNameKana>
+  <!-- <schema:additionalName xml:lang="ja"></schema:additionalName> -->
+  <!-- <schema:additionalName xml:lang="en"></schema:additionalName> -->
+  <!-- <lily:additionalNameKana xml:lang="ja"></lily:additionalNameKana> -->
+  <schema:givenName xml:lang="ja">鳳蝶</schema:givenName>
+  <schema:givenName xml:lang="en">Ageha</schema:givenName>
+  <lily:givenNameKana xml:lang="ja">あげは</lily:givenNameKana>
+  <schema:name xml:lang="ja">吉田鳳蝶</schema:name>
+  <schema:name xml:lang="en">Yoshida Ageha</schema:name>
+  <lily:nameKana xml:lang="ja">よしだあげは</lily:nameKana>
+  <!-- <lily:anotherName xml:lang="ja"></lily:anotherName> -->
+  <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
+  <!-- <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:height> -->
+  <!-- <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:weight> -->
+  <!-- <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay"></schema:birthDate> -->
+  <lily:lifeStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alive</lily:lifeStatus>
+  <!-- <lily:killedIn xml:lang="ja"></lily:killedIn> -->
+  <!-- <lily:bloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:bloodType> -->
+  <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
+  <!-- <lily:color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary"></lily:color> -->
+  <!-- <schema:birthPlace xml:lang="ja"></schema:birthPlace> -->
+  <!-- <schema:birthPlace xml:lang="en"></schema:birthPlace> -->
+  <!-- <lily:favorite xml:lang="ja"></lily:favorite> -->
+  <!-- <lily:notGood xml:lang="ja"></lily:notGood> -->
+  <!-- <lily:hobby_talent xml:lang="ja"></lily:hobby_talent> -->
+  <lily:rareSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ヘリオスフィア</lily:rareSkill>
+  <!-- <lily:subSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:subSkill> -->
+  <lily:isBoosted rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</lily:isBoosted>
+  <!-- <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:boostedSkill> -->
+  <!-- <lily:charm rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:usedIn> -->
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <!-- </lily:charm> -->
+  <lily:garden rdf:datatype="http://www.w3.org/2001/XMLSchema#string">私立百合ヶ丘女学院</lily:garden>
+  <lily:gardenDepartment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">普通科</lily:gardenDepartment>
+  <lily:grade rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</lily:grade>
+  <!-- <lily:class rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:class> -->
+  <lily:gardenJobTitle xml:lang="ja">倫理道徳勉強会主宰(ヴァール)</lily:gardenJobTitle>
+  <lily:legion rdf:resource="Herfjotur"/>
+  <lily:legionJobTitle rdf:datatype="http://www.w3.org/2001/XMLSchema#string">隊長</lily:legionJobTitle>
+  <!-- <lily:position rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:position> -->
+  <!-- <lily:pastLegion rdf:resource=""/> -->
+  <!-- <lily:taskforce rdf:resource=""/> -->
+  <!-- <lily:schutzengel rdf:resource=""/> -->
+  <!-- <lily:pastSchutzengel rdf:resource=""/> -->
+  <lily:schild rdf:resource="Sakaizawa_Naru"/>
+  <!-- <lily:pastSchild rdf:resource=""/> -->
+  <!-- <lily:roomMate rdf:resource=""/> -->
+  <!-- <schema:parent rdf:resource=""/> -->
+  <!-- <schema:sibling rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <!-- </schema:sibling> -->
+  <!-- <lily:relationship rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <!-- </lily:relationship> -->
+  <!-- <lily:cast rdf:parseType="Resource"> -->
+    <!-- <schema:name xml:lang="ja"></schema:name> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:performIn rdf:resource=""/> -->
+  <!-- </lily:cast> -->
+  <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
+</rdf:Description>
+
 
 <!-- LG不明・無所属 -->
 


### PR DESCRIPTION
### 概要

新リリィ、及びレギオン情報を追加し、既存のリリィの情報を更新します。

#### 新たに追加される情報
* `Yoshida_Ageha` - 新リリィ「吉田鳳蝶」
* `Herfjotur` - LG「ヘルフィヨトゥル」

#### 上記追加により更新される情報
* `Sakaizawa_Naru` - 「境沢奈留」のシュッツエンゲルは「吉田鳳蝶」


### 情報源

- Reply tree : https://twitter.com/assault_lily/status/1395027317756293121

### チェック項目

この変更は
- [ ] 新しいクラスやプロパティ定義を追加する
- [ ] 既存のデータ構造の破壊的な変更を含む
- [ ] 既存のRDF制約に違反しており、制約を緩和する必要がある

### 特記事項

* 過去ジーグルーネを務めたロザリンデ様、及び竹腰千華様を`lily:relationship`には登録していません。必要であれば追加お願いします。

### 追伸

佐世保外征たのしかったです

![image](https://user-images.githubusercontent.com/12165058/118839572-8f95d800-b901-11eb-815c-14497814e7b5.png)

