### PR TITLE
LGロスヴァイセを追加

### DIFF
--- a/RDFs/charm.rdf
+++ b/RDFs/charm.rdf
@@ -325,7 +325,7 @@
   <schema:manufacturer rdf:resource="Hihiirokane_International"/>
   <lily:user rdf:resource="Wang_Yujia"/>
   <lily:user rdf:resource="Kuo_Shenlin"/>
-  <!-- <lily:user rdf:resource="Ishigami_Mio"/> -->
+  <lily:user rdf:resource="Ishigami_Mio"/>
   <lily:user rdf:resource="Ishikawa_Aoi"/>
   <lily:user rdf:resource="Izue_Shinobu"/>
   <lily:user rdf:resource="Imagawa_Homare"/>
@@ -339,7 +339,7 @@
   <lily:user rdf:resource="Banshoya_Ena"/>
   <lily:user rdf:resource="Mashima_Moyu"/>
   <!-- <lily:user rdf:resource="Yumeno_Kanon"/> -->
-  <!-- <lily:user rdf:resource="Rosalinde_Friedegunde_von_Otto"/> -->
+  <lily:user rdf:resource="Rosalinde_Friedegunde_von_Otto"/>
   <lily:user rdf:resource="Watanabe_Akane"/>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Charm"/>
 </rdf:Description>

--- a/RDFs/legion.rdf
+++ b/RDFs/legion.rdf
@@ -254,6 +254,26 @@
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Legion"/>
 </rdf:Description>
 
+<rdf:Description rdf:about="Rossweisse">
+  <schema:name xml:lang="ja">ロスヴァイセ</schema:name>
+  <schema:name xml:lang="en">Rossweisse</schema:name>
+  <!-- <schema:alternateName xml:lang="ja"></schema:alternateName> -->
+  <!-- <schema:alternateName xml:lang="en"></schema:alternateName> -->
+  <lily:disbanded rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</lily:disbanded>
+  <lily:legionGrade rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SS</lily:legionGrade>
+  <!-- <lily:numberOfMembers rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:numberOfMembers> -->
+  <schema:member rdf:resource="Kitagawara_Inori"/><!-- 隊長 -->
+  <schema:member rdf:resource="Ishigami_Mio"/><!-- 副隊長 -->
+  <schema:member rdf:resource="Rosalinde_Friedegunde_von_Otto"/>
+  <!-- <schema:member rdf:resource="Oshima_"/> --><!-- 大島某 -->
+  <!-- <schema:member rdf:resource="Goto_"/> --><!-- 後藤某 -->
+  <schema:member rdf:resource="Yamada_Samidori"/>
+  <!-- <schema:member rdf:resource="Kaneda_"/> --><!-- 金田某 -->
+  <schema:member rdf:resource="Onogi_Sato"/>
+  <schema:member rdf:resource="Yasui_Ryo"/>
+  <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Legion"/>
+</rdf:Description>
+
 <rdf:Description rdf:about="Herfjotur">
   <schema:name xml:lang="ja">ヘルフィヨトゥル</schema:name>
   <schema:name xml:lang="en">Herfjötur</schema:name>

--- a/RDFs/lily_yurigaoka.rdf
+++ b/RDFs/lily_yurigaoka.rdf
@@ -2414,7 +2414,7 @@
     <lily:resource rdf:resource="Ishigami_Mio"/>
     <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation>
   </lily:relationship>
-  <!--lily:cast rdf:parseType="Resource"> -->
+  <!-- <lily:cast rdf:parseType="Resource"> -->
     <!-- <schema:name xml:lang="ja"></schema:name> -->
     <!-- <lily:resource rdf:resource=""/> -->
     <!-- <lily:performIn rdf:resource=""/> -->
@@ -7123,7 +7123,7 @@
 </rdf:Description>
 
 <rdf:Description rdf:about="Rosalinde_Friedegunde_von_Otto">
-  <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロザリンデ・フリーデグンデ・フォン・オットー</rdfs:label>
+  <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロザリンデ・フリーデグンデ・v・オットー</rdfs:label>
   <schema:familyName xml:lang="ja">フォン・オットー</schema:familyName>
   <schema:familyName xml:lang="en">von Otto</schema:familyName>
   <lily:familyNameKana xml:lang="ja">ふぉん・おっとー</lily:familyNameKana>
@@ -7133,7 +7133,7 @@
   <schema:givenName xml:lang="ja">ロザリンデ</schema:givenName>
   <schema:givenName xml:lang="en">Rosalinde</schema:givenName>
   <lily:givenNameKana xml:lang="ja">ろざりんで</lily:givenNameKana>
-  <schema:name xml:lang="ja">ロザリンデ・フリーデグンデ・フォン・オットー</schema:name>
+  <schema:name xml:lang="ja">ロザリンデ・フリーデグンデ・v・オットー</schema:name>
   <schema:name xml:lang="en">Rosalinde Friedegunde von Otto</schema:name>
   <lily:nameKana xml:lang="ja">ろざりんで・ふりーでぐんで・ふぉん・おっとー</lily:nameKana>
   <!-- <lily:anotherName xml:lang="ja"></lily:anotherName> -->

--- a/RDFs/lily_yurigaoka.rdf
+++ b/RDFs/lily_yurigaoka.rdf
@@ -7155,7 +7155,7 @@
   <!-- <lily:subSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:subSkill> -->
   <lily:isBoosted rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</lily:isBoosted>
   <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">リジェネレーター</lily:boostedSkill>
-  <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エ－テルボディ</lily:boostedSkill>
+  <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エーテルボディ</lily:boostedSkill>
   <lily:charm rdf:parseType="Resource">
     <lily:resource rdf:resource="Asterion"/>
     <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アニメ</lily:usedIn>

--- a/RDFs/lily_yurigaoka.rdf
+++ b/RDFs/lily_yurigaoka.rdf
@@ -7102,7 +7102,7 @@
   <!-- <lily:taskforce rdf:resource=""/> -->
   <lily:schutzengel rdf:resource="Rosalinde_Friedegunde_von_Otto"/>
   <!-- <lily:pastSchutzengel rdf:resource=""/> -->
-  <lily:schild rdf:resource="Kitagawara_Inori"/> -->
+  <lily:schild rdf:resource="Kitagawara_Inori"/>
   <!-- <lily:pastSchild rdf:resource=""/> -->
   <lily:roomMate rdf:resource="Rosalinde_Friedegunde_von_Otto"/>
   <!-- <schema:parent rdf:resource=""/> -->

--- a/RDFs/lily_yurigaoka.rdf
+++ b/RDFs/lily_yurigaoka.rdf
@@ -2299,10 +2299,10 @@
     <!-- <lily:resource rdf:resource="Yumeno_Kanon"/> -->
     <!-- <lily:additionalInformation xml:lang="ja">山梨時代の親友</lily:additionalInformation> -->
   <!-- </lily:relationship> -->
-  <!-- <lily:relationship rdf:parseType="Resource"> -->
-    <!-- <lily:resource rdf:resource="Rosalinde_Friedegunde_von_Otto"/> -->
-    <!-- <lily:additionalInformation xml:lang="ja">そうさく倶楽部</lily:additionalInformation> -->
-  <!-- </lily:relationship> -->
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Rosalinde_Friedegunde_von_Otto"/>
+    <lily:additionalInformation xml:lang="ja">そうさく倶楽部</lily:additionalInformation>
+  </lily:relationship>
   <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Yamazaki_Meika"/>
     <lily:additionalInformation xml:lang="ja">そうさく倶楽部</lily:additionalInformation>
@@ -2410,11 +2410,11 @@
     <lily:additionalInformation xml:lang="ja">元相棒</lily:additionalInformation>
     <lily:additionalInformation xml:lang="ja">発見救助を目指す</lily:additionalInformation>
   </lily:relationship>
-  <!-- <lily:relationship rdf:parseType="Resource"> -->
-    <!-- <lily:resource rdf:resource="Ishigami_Mio"/> -->
-    <!-- <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation> -->
-  <!-- </lily:relationship> -->
-  <!-- <lily:cast rdf:parseType="Resource"> -->
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Ishigami_Mio"/>
+    <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation>
+  </lily:relationship>
+  <!--lily:cast rdf:parseType="Resource"> -->
     <!-- <schema:name xml:lang="ja"></schema:name> -->
     <!-- <lily:resource rdf:resource=""/> -->
     <!-- <lily:performIn rdf:resource=""/> -->
@@ -2980,10 +2980,10 @@
     <!-- <lily:resource rdf:resource=""/> -->
     <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
   <!-- </schema:sibling> -->
-  <!-- <lily:relationship rdf:parseType="Resource"> -->
-    <!-- <lily:resource rdf:resource="Rosalinde_Friedegunde_von_Otto"/> -->
-    <!-- <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation> -->
-  <!-- </lily:relationship> -->
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Rosalinde_Friedegunde_von_Otto"/>
+    <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation>
+  </lily:relationship>
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">三浦千幸</schema:name>
     <lily:resource rdf:resource="https://www.wikidata.org/wiki/Q65095700"/>
@@ -5093,6 +5093,10 @@
     <lily:resource rdf:resource="Hitotsuyanagi_Riri"/>
     <lily:additionalInformation xml:lang="ja">生涯の友となる</lily:additionalInformation>
   </lily:relationship>
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Onogi_Sato"/>
+    <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation>
+  </lily:relationship>
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">七瀬彩夏</schema:name>
     <lily:resource rdf:resource="https://www.wikidata.org/wiki/Q22126767"/>
@@ -6679,10 +6683,10 @@
     <lily:resource rdf:resource="Rokkaku_Shiori"/>
     <lily:additionalInformation xml:lang="ja">そうさく俱楽部</lily:additionalInformation>
   </lily:relationship>
-  <!-- <lily:relationship rdf:parseType="Resource"> -->
-    <!-- <lily:resource rdf:resource="Rosalinde_Friedegunde_von_Otto"/> -->
-    <!-- <lily:additionalInformation xml:lang="ja">そうさく倶楽部</lily:additionalInformation> -->
-  <!-- </lily:relationship> -->
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Rosalinde_Friedegunde_von_Otto"/>
+    <lily:additionalInformation xml:lang="ja">そうさく倶楽部</lily:additionalInformation>
+  </lily:relationship>
   <!-- <lily:cast rdf:parseType="Resource"> -->
     <!-- <schema:name xml:lang="ja"></schema:name> -->
     <!-- <lily:resource rdf:resource=""/> -->
@@ -6974,6 +6978,442 @@
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
 </rdf:Description>
 
+<!-- LGロスヴァイセ -->
+
+<rdf:Description rdf:about="Kitagawara_Inori">
+  <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">北河原伊紀</rdfs:label>
+  <schema:familyName xml:lang="ja">北河原</schema:familyName>
+  <schema:familyName xml:lang="en">Kitagawara</schema:familyName>
+  <lily:familyNameKana xml:lang="ja">きたがわら</lily:familyNameKana>
+  <!-- <schema:additionalName xml:lang="ja"></schema:additionalName> -->
+  <!-- <schema:additionalName xml:lang="en"></schema:additionalName> -->
+  <!-- <lily:additionalNameKana xml:lang="ja"></lily:additionalNameKana> -->
+  <schema:givenName xml:lang="ja">伊紀</schema:givenName>
+  <schema:givenName xml:lang="en">Inori</schema:givenName>
+  <lily:givenNameKana xml:lang="ja">いのり</lily:givenNameKana>
+  <schema:name xml:lang="ja">北河原伊紀</schema:name>
+  <schema:name xml:lang="en">Kitagawara Inori</schema:name>
+  <lily:nameKana xml:lang="ja">きたがわらいのり</lily:nameKana>
+  <!-- <lily:anotherName xml:lang="ja"></lily:anotherName> -->
+  <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
+  <!-- <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:height> -->
+  <!-- <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:weight> -->
+  <!-- <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay"></schema:birthDate> -->
+  <lily:lifeStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alive</lily:lifeStatus>
+  <!-- <lily:killedIn xml:lang="ja"></lily:killedIn> -->
+  <!-- <lily:bloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:bloodType> -->
+  <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
+  <!-- <lily:color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary"></lily:color> -->
+  <!-- <schema:birthPlace xml:lang="ja"></schema:birthPlace> -->
+  <!-- <schema:birthPlace xml:lang="en"></schema:birthPlace> -->
+  <!-- <lily:favorite xml:lang="ja"></lily:favorite> -->
+  <!-- <lily:notGood xml:lang="ja"></lily:notGood> -->
+  <!-- <lily:hobby_talent xml:lang="ja"></lily:hobby_talent> -->
+  <lily:rareSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Z</lily:rareSkill>
+  <!-- <lily:subSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:subSkill> -->
+  <lily:isBoosted rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</lily:isBoosted>
+  <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">リジェネレーター</lily:boostedSkill>
+  <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アルケミートレース</lily:boostedSkill>
+  <!-- <lily:charm rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:usedIn> -->
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <!-- </lily:charm> -->
+  <lily:garden rdf:datatype="http://www.w3.org/2001/XMLSchema#string">私立百合ヶ丘女学院</lily:garden>
+  <lily:gardenDepartment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">普通科</lily:gardenDepartment>
+  <lily:grade rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</lily:grade>
+  <lily:class rdf:datatype="http://www.w3.org/2001/XMLSchema#string">李組</lily:class>
+  <lily:gardenJobTitle xml:lang="ja">学級委員長</lily:gardenJobTitle>
+  <lily:legion rdf:resource="Rossweisse"/>
+  <lily:legionJobTitle rdf:datatype="http://www.w3.org/2001/XMLSchema#string">隊長</lily:legionJobTitle>
+  <!-- <lily:position rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:position> -->
+  <!-- <lily:pastLegion rdf:resource=""/> -->
+  <!-- <lily:taskforce rdf:resource=""/> -->
+  <lily:schutzengel rdf:resource="Ishigami_Mio"/>
+  <!-- <lily:pastSchutzengel rdf:resource=""/> -->
+  <!-- <lily:schild rdf:resource=""/> -->
+  <!-- <lily:pastSchild rdf:resource=""/> -->
+  <lily:roomMate rdf:resource="Onogi_Sato"/>
+  <!-- <schema:parent rdf:resource=""/> -->
+  <!-- <schema:sibling rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <!-- </schema:sibling> -->
+  <!-- <lily:relationship rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <!-- </lily:relationship> -->
+  <!-- <lily:cast rdf:parseType="Resource"> -->
+    <!-- <schema:name xml:lang="ja"></schema:name> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:performIn rdf:resource=""/> -->
+  <!-- </lily:cast> -->
+  <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="Ishigami_Mio">
+  <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">石上碧乙</rdfs:label>
+  <schema:familyName xml:lang="ja">石上</schema:familyName>
+  <schema:familyName xml:lang="en">Ishigami</schema:familyName>
+  <lily:familyNameKana xml:lang="ja">いしがみ</lily:familyNameKana>
+  <!-- <schema:additionalName xml:lang="ja"></schema:additionalName> -->
+  <!-- <schema:additionalName xml:lang="en"></schema:additionalName> -->
+  <!-- <lily:additionalNameKana xml:lang="ja"></lily:additionalNameKana> -->
+  <schema:givenName xml:lang="ja">碧乙</schema:givenName>
+  <schema:givenName xml:lang="en">Mio</schema:givenName>
+  <lily:givenNameKana xml:lang="ja">みお</lily:givenNameKana>
+  <schema:name xml:lang="ja">石上碧乙</schema:name>
+  <schema:name xml:lang="en">Ishigami Mio</schema:name>
+  <lily:nameKana xml:lang="ja">いしがみみお</lily:nameKana>
+  <lily:anotherName xml:lang="ja">ガラスの天才</lily:anotherName>
+  <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
+  <!-- <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:height> -->
+  <!-- <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:weight> -->
+  <!-- <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay"></schema:birthDate> -->
+  <lily:lifeStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alive</lily:lifeStatus>
+  <!-- <lily:killedIn xml:lang="ja"></lily:killedIn> -->
+  <!-- <lily:bloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:bloodType> -->
+  <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
+  <!-- <lily:color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary"></lily:color> -->
+  <!-- <schema:birthPlace xml:lang="ja"></schema:birthPlace> -->
+  <!-- <schema:birthPlace xml:lang="en"></schema:birthPlace> -->
+  <!-- <lily:favorite xml:lang="ja"></lily:favorite> -->
+  <!-- <lily:notGood xml:lang="ja"></lily:notGood> -->
+  <!-- <lily:hobby_talent xml:lang="ja"></lily:hobby_talent> -->
+  <lily:rareSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ファンタズム</lily:rareSkill>
+  <!-- <lily:subSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:subSkill> -->
+  <lily:isBoosted rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</lily:isBoosted>
+  <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">オートヒール</lily:boostedSkill>
+  <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エンハンスメント</lily:boostedSkill>
+  <lily:charm rdf:parseType="Resource">
+    <lily:resource rdf:resource="Asterion"/>
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アニメ</lily:usedIn>
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  </lily:charm>
+  <lily:garden rdf:datatype="http://www.w3.org/2001/XMLSchema#string">私立百合ヶ丘女学院</lily:garden>
+  <!-- <lily:gardenDepartment rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:gardenDepartment> -->
+  <lily:grade rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</lily:grade>
+  <!-- <lily:class rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:class> -->
+  <!-- <lily:gardenJobTitle xml:lang="ja"></lily:gardenJobTitle> -->
+  <lily:legion rdf:resource="Rossweisse"/>
+  <lily:legionJobTitle rdf:datatype="http://www.w3.org/2001/XMLSchema#string">副隊長</lily:legionJobTitle>
+  <lily:position rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AZ</lily:position><!-- 初期ポジション表からの推定 -->
+  <!-- <lily:pastLegion rdf:resource=""/> -->
+  <!-- <lily:taskforce rdf:resource=""/> -->
+  <lily:schutzengel rdf:resource="Rosalinde_Friedegunde_von_Otto"/>
+  <!-- <lily:pastSchutzengel rdf:resource=""/> -->
+  <lily:schild rdf:resource="Kitagawara_Inori"/> -->
+  <!-- <lily:pastSchild rdf:resource=""/> -->
+  <lily:roomMate rdf:resource="Rosalinde_Friedegunde_von_Otto"/>
+  <!-- <schema:parent rdf:resource=""/> -->
+  <!-- <schema:sibling rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <!-- </schema:sibling> -->
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Taniguchi_Hijiri"/>
+    <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation>
+  </lily:relationship>
+  <!-- <lily:cast rdf:parseType="Resource"> -->
+    <!-- <schema:name xml:lang="ja"></schema:name> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:performIn rdf:resource=""/> -->
+  <!-- </lily:cast> -->
+  <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="Rosalinde_Friedegunde_von_Otto">
+  <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロザリンデ・フリーデグンデ・フォン・オットー</rdfs:label>
+  <schema:familyName xml:lang="ja">フォン・オットー</schema:familyName>
+  <schema:familyName xml:lang="en">von Otto</schema:familyName>
+  <lily:familyNameKana xml:lang="ja">ふぉん・おっとー</lily:familyNameKana>
+  <schema:additionalName xml:lang="ja">フリーデグンデ</schema:additionalName>
+  <schema:additionalName xml:lang="en">Friedegunde</schema:additionalName>
+  <lily:additionalNameKana xml:lang="ja">ふりーでぐんで</lily:additionalNameKana>
+  <schema:givenName xml:lang="ja">ロザリンデ</schema:givenName>
+  <schema:givenName xml:lang="en">Rosalinde</schema:givenName>
+  <lily:givenNameKana xml:lang="ja">ろざりんで</lily:givenNameKana>
+  <schema:name xml:lang="ja">ロザリンデ・フリーデグンデ・フォン・オットー</schema:name>
+  <schema:name xml:lang="en">Rosalinde Friedegunde von Otto</schema:name>
+  <lily:nameKana xml:lang="ja">ろざりんで・ふりーでぐんで・ふぉん・おっとー</lily:nameKana>
+  <!-- <lily:anotherName xml:lang="ja"></lily:anotherName> -->
+  <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
+  <!-- <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:height> -->
+  <!-- <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:weight> -->
+  <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-24</schema:birthDate>
+  <lily:lifeStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alive</lily:lifeStatus>
+  <!-- <lily:killedIn xml:lang="ja"></lily:killedIn> -->
+  <!-- <lily:bloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:bloodType> -->
+  <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
+  <!-- <lily:color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary"></lily:color> -->
+  <!-- <schema:birthPlace xml:lang="ja"></schema:birthPlace> -->
+  <!-- <schema:birthPlace xml:lang="en"></schema:birthPlace> -->
+  <!-- <lily:favorite xml:lang="ja"></lily:favorite> -->
+  <!-- <lily:notGood xml:lang="ja"></lily:notGood> -->
+  <lily:hobby_talent xml:lang="ja">彫金（アクセサリー作り）</lily:hobby_talent>
+  <lily:rareSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フェイズトランセンデンス</lily:rareSkill>
+  <!-- <lily:subSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:subSkill> -->
+  <lily:isBoosted rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</lily:isBoosted>
+  <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">リジェネレーター</lily:boostedSkill>
+  <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エ－テルボディ</lily:boostedSkill>
+  <lily:charm rdf:parseType="Resource">
+    <lily:resource rdf:resource="Asterion"/>
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アニメ</lily:usedIn>
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  </lily:charm>
+  <lily:garden rdf:datatype="http://www.w3.org/2001/XMLSchema#string">私立百合ヶ丘女学院</lily:garden>
+  <!-- <lily:gardenDepartment rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:gardenDepartment> -->
+  <lily:grade rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</lily:grade>
+  <!-- <lily:class rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:class> -->
+  <lily:gardenJobTitle xml:lang="ja">規律審院特別顧問</lily:gardenJobTitle>
+  <lily:legion rdf:resource="Rossweisse"/>
+  <!-- lily:legionJobTitle rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:legionJobTitle> -->
+  <lily:position rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AZ</lily:position><!-- 初期ポジション表からの推定 -->
+  <!-- <lily:pastLegion rdf:resource=""/> -->
+  <!-- <lily:taskforce rdf:resource=""/> -->
+  <!-- <lily:schutzengel rdf:resource=""/> -->
+  <!-- <lily:pastSchutzengel rdf:resource=""/> -->
+  <lily:schild rdf:resource="Kitagawara_Inori"/>
+  <!-- <lily:pastSchild rdf:resource=""/> -->
+  <lily:roomMate rdf:resource="Kitagawara_Inori"/>
+  <!-- <schema:parent rdf:resource=""/> -->
+  <!-- <schema:sibling rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <!-- </schema:sibling> -->
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Tamura_Nagi"/>
+    <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation>
+  </lily:relationship>
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Rokkaku_Shiori"/>
+    <lily:additionalInformation xml:lang="ja">そうさく倶楽部</lily:additionalInformation>
+  </lily:relationship>
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Yamazaki_Meika"/>
+    <lily:additionalInformation xml:lang="ja">そうさく倶楽部</lily:additionalInformation>
+  </lily:relationship>
+  <!-- <lily:relationship rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource="Morishita_Miyabi"/> -->
+    <!-- <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation> -->
+  <!-- </lily:relationship> -->
+  <lily:cast rdf:parseType="Resource">
+    <schema:name xml:lang="ja">綾瀬有</schema:name>
+    <lily:resource rdf:resource="https://www.wikidata.org/wiki/Q11607345"/>
+    <lily:performIn rdf:resource="Assault_Lily_Bouquet"/>
+  </lily:cast>
+  <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="Yamada_Samidori">
+  <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">山田早緑</rdfs:label>
+  <schema:familyName xml:lang="ja">山田</schema:familyName>
+  <schema:familyName xml:lang="en">Yamada</schema:familyName>
+  <lily:familyNameKana xml:lang="ja">やまだ</lily:familyNameKana>
+  <!-- <schema:additionalName xml:lang="ja"></schema:additionalName> -->
+  <!-- <schema:additionalName xml:lang="en"></schema:additionalName> -->
+  <!-- <lily:additionalNameKana xml:lang="ja"></lily:additionalNameKana> -->
+  <schema:givenName xml:lang="ja">早緑</schema:givenName>
+  <schema:givenName xml:lang="en">Samidori</schema:givenName>
+  <lily:givenNameKana xml:lang="ja">さみどり</lily:givenNameKana>
+  <schema:name xml:lang="ja">山田早緑</schema:name>
+  <schema:name xml:lang="en">Yamada Samidori</schema:name>
+  <lily:nameKana xml:lang="ja">やまださみどり</lily:nameKana>
+  <!-- <lily:anotherName xml:lang="ja"></lily:anotherName> -->
+  <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
+  <!-- <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:height> -->
+  <!-- <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:weight> -->
+  <!-- <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay"></schema:birthDate> -->
+  <lily:lifeStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alive</lily:lifeStatus>
+  <!-- <lily:killedIn xml:lang="ja"></lily:killedIn> -->
+  <!-- <lily:bloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:bloodType> -->
+  <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
+  <!-- <lily:color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary"></lily:color> -->
+  <!-- <schema:birthPlace xml:lang="ja"></schema:birthPlace> -->
+  <!-- <schema:birthPlace xml:lang="en"></schema:birthPlace> -->
+  <!-- <lily:favorite xml:lang="ja"></lily:favorite> -->
+  <!-- <lily:notGood xml:lang="ja"></lily:notGood> -->
+  <!-- <lily:hobby_talent xml:lang="ja"></lily:hobby_talent> -->
+  <!-- <lily:rareSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:rareSkill> -->
+  <!-- <lily:subSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:subSkill> -->
+  <lily:isBoosted rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</lily:isBoosted>
+  <!-- <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:boostedSkill> -->
+  <!-- <lily:charm rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:usedIn> -->
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <!-- </lily:charm> -->
+  <lily:garden rdf:datatype="http://www.w3.org/2001/XMLSchema#string">私立百合ヶ丘女学院</lily:garden>
+  <lily:gardenDepartment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">普通科</lily:gardenDepartment>
+  <lily:grade rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</lily:grade>
+  <lily:class rdf:datatype="http://www.w3.org/2001/XMLSchema#string">椿組</lily:class>
+  <!-- <lily:gardenJobTitle xml:lang="ja"></lily:gardenJobTitle> -->
+  <lily:legion rdf:resource="Rossweisse"/>
+  <!-- <lily:legionJobTitle rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:legionJobTitle> -->
+  <lily:position rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TZ</lily:position><!-- 初期ポジション表からの推定 -->
+  <!-- <lily:pastLegion rdf:resource=""/> -->
+  <!-- <lily:taskforce rdf:resource=""/> -->
+  <!-- <lily:schutzengel rdf:resource=""/> -->
+  <!-- <lily:pastSchutzengel rdf:resource=""/> -->
+  <!-- <lily:schild rdf:resource=""/> -->
+  <!-- <lily:pastSchild rdf:resource=""/> -->
+  <!-- <lily:roomMate rdf:resource=""/> -->
+  <!-- <schema:parent rdf:resource=""/> -->
+  <!-- <schema:sibling rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <!-- </schema:sibling> -->
+  <!-- <lily:relationship rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <!-- </lily:relationship> -->
+  <!-- <lily:cast rdf:parseType="Resource"> -->
+    <!-- <schema:name xml:lang="ja"></schema:name> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:performIn rdf:resource=""/> -->
+  <!-- </lily:cast> -->
+  <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="Onogi_Sato">
+  <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">小野木瑳都</rdfs:label>
+  <schema:familyName xml:lang="ja">小野木</schema:familyName>
+  <schema:familyName xml:lang="en">Onogi</schema:familyName>
+  <lily:familyNameKana xml:lang="ja">おのぎ</lily:familyNameKana>
+  <!-- <schema:additionalName xml:lang="ja"></schema:additionalName> -->
+  <!-- <schema:additionalName xml:lang="en"></schema:additionalName> -->
+  <!-- <lily:additionalNameKana xml:lang="ja"></lily:additionalNameKana> -->
+  <schema:givenName xml:lang="ja">瑳都</schema:givenName>
+  <schema:givenName xml:lang="en">Sato</schema:givenName>
+  <lily:givenNameKana xml:lang="ja">さと</lily:givenNameKana>
+  <schema:name xml:lang="ja">小野木瑳都</schema:name>
+  <schema:name xml:lang="en">Onogi Sato</schema:name>
+  <lily:nameKana xml:lang="ja">おのぎさと</lily:nameKana>
+  <!-- <lily:anotherName xml:lang="ja"></lily:anotherName> -->
+  <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
+  <!-- <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:height> -->
+  <!-- <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:weight> -->
+  <!-- <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay"></schema:birthDate> -->
+  <lily:lifeStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alive</lily:lifeStatus>
+  <!-- <lily:killedIn xml:lang="ja"></lily:killedIn> -->
+  <!-- <lily:bloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:bloodType> -->
+  <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
+  <!-- <lily:color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary"></lily:color> -->
+  <!-- <schema:birthPlace xml:lang="ja"></schema:birthPlace> -->
+  <!-- <schema:birthPlace xml:lang="en"></schema:birthPlace> -->
+  <!-- <lily:favorite xml:lang="ja"></lily:favorite> -->
+  <!-- <lily:notGood xml:lang="ja"></lily:notGood> -->
+  <!-- <lily:hobby_talent xml:lang="ja"></lily:hobby_talent> -->
+  <!-- <lily:rareSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:rareSkill> -->
+  <!-- <lily:subSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:subSkill> -->
+  <lily:isBoosted rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</lily:isBoosted>
+  <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ドレイン</lily:boostedSkill>
+  <!-- <lily:charm rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:usedIn> -->
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <!-- </lily:charm> -->
+  <lily:garden rdf:datatype="http://www.w3.org/2001/XMLSchema#string">私立百合ヶ丘女学院</lily:garden>
+  <lily:gardenDepartment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">普通科</lily:gardenDepartment>
+  <lily:grade rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</lily:grade>
+  <lily:class rdf:datatype="http://www.w3.org/2001/XMLSchema#string">李組</lily:class>
+  <!-- <lily:gardenJobTitle xml:lang="ja"></lily:gardenJobTitle> -->
+  <lily:legion rdf:resource="Rossweisse"/>
+  <!-- <lily:legionJobTitle rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:legionJobTitle> -->
+  <lily:position rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BZ</lily:position>
+  <!-- <lily:pastLegion rdf:resource=""/> -->
+  <!-- <lily:taskforce rdf:resource=""/> -->
+  <!-- <lily:schutzengel rdf:resource=""/> -->
+  <!-- <lily:pastSchutzengel rdf:resource=""/> -->
+  <!-- <lily:schild rdf:resource=""/> -->
+  <!-- <lily:pastSchild rdf:resource=""/> -->
+  <lily:roomMate rdf:resource="Kitagawara_Inori"/>
+  <!-- <schema:parent rdf:resource=""/> -->
+  <!-- <schema:sibling rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <!-- </schema:sibling> -->
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Ito_Shizu"/>
+    <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation>
+  </lily:relationship>
+  <!-- <lily:cast rdf:parseType="Resource"> -->
+    <!-- <schema:name xml:lang="ja"></schema:name> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:performIn rdf:resource=""/> -->
+  <!-- </lily:cast> -->
+  <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="Yasui_Ryo">
+  <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">安井諒</rdfs:label>
+  <schema:familyName xml:lang="ja">安井</schema:familyName>
+  <schema:familyName xml:lang="en">Yasui</schema:familyName>
+  <!-- <lily:familyNameKana xml:lang="ja"></lily:familyNameKana> -->
+  <!-- <schema:additionalName xml:lang="ja"></schema:additionalName> -->
+  <!-- <schema:additionalName xml:lang="en"></schema:additionalName> -->
+  <!-- <lily:additionalNameKana xml:lang="ja"></lily:additionalNameKana> -->
+  <schema:givenName xml:lang="ja">諒</schema:givenName>
+  <schema:givenName xml:lang="en">Ryo</schema:givenName>
+  <!-- <lily:givenNameKana xml:lang="ja"></lily:givenNameKana> -->
+  <schema:name xml:lang="ja">安井諒</schema:name>
+  <schema:name xml:lang="en">Yasui Ryo</schema:name>
+  <lily:nameKana xml:lang="ja"></lily:nameKana>
+  <!-- <lily:anotherName xml:lang="ja"></lily:anotherName> -->
+  <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
+  <!-- <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:height> -->
+  <!-- <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:weight> -->
+  <!-- <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay"></schema:birthDate> -->
+  <lily:lifeStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alive</lily:lifeStatus>
+  <!-- <lily:killedIn xml:lang="ja"></lily:killedIn> -->
+  <!-- <lily:bloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:bloodType> -->
+  <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
+  <!-- <lily:color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary"></lily:color> -->
+  <!-- <schema:birthPlace xml:lang="ja"></schema:birthPlace> -->
+  <!-- <schema:birthPlace xml:lang="en"></schema:birthPlace> -->
+  <!-- <lily:favorite xml:lang="ja"></lily:favorite> -->
+  <!-- <lily:notGood xml:lang="ja"></lily:notGood> -->
+  <!-- <lily:hobby_talent xml:lang="ja"></lily:hobby_talent> -->
+  <!-- <lily:rareSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:rareSkill> -->
+  <!-- <lily:subSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:subSkill> -->
+  <lily:isBoosted rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</lily:isBoosted>
+  <!-- <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:boostedSkill> -->
+  <!-- <lily:charm rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:usedIn> -->
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <!-- </lily:charm> -->
+  <lily:garden rdf:datatype="http://www.w3.org/2001/XMLSchema#string">私立百合ヶ丘女学院</lily:garden>
+  <lily:gardenDepartment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">普通科</lily:gardenDepartment>
+  <lily:grade rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</lily:grade>
+  <lily:class rdf:datatype="http://www.w3.org/2001/XMLSchema#string">椿組</lily:class>
+  <!-- <lily:gardenJobTitle xml:lang="ja"></lily:gardenJobTitle> -->
+  <lily:legion rdf:resource="Rossweisse"/>
+  <!-- <lily:legionJobTitle rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:legionJobTitle> -->
+  <lily:position rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BZ</lily:position><!-- 初期ポジション表からの推定 -->
+  <!-- <lily:pastLegion rdf:resource=""/> -->
+  <!-- <lily:taskforce rdf:resource=""/> -->
+  <!-- <lily:schutzengel rdf:resource=""/> -->
+  <!-- <lily:pastSchutzengel rdf:resource=""/> -->
+  <!-- <lily:schild rdf:resource=""/> -->
+  <!-- <lily:pastSchild rdf:resource=""/> -->
+  <!-- <lily:roomMate rdf:resource=""/> -->
+  <!-- <schema:parent rdf:resource=""/> -->
+  <!-- <schema:sibling rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <!-- </schema:sibling> -->
+  <!-- <lily:relationship rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <!-- </lily:relationship> -->
+  <!-- <lily:cast rdf:parseType="Resource"> -->
+    <!-- <schema:name xml:lang="ja"></schema:name> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:performIn rdf:resource=""/> -->
+  <!-- </lily:cast> -->
+  <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
+</rdf:Description>
 
 <!-- LGヘルフィヨトゥル -->
 

--- a/constraints/Lily_Shape.ttl
+++ b/constraints/Lily_Shape.ttl
@@ -258,6 +258,8 @@ lily-shape:lilyShape a sh:NodeShape;
             "連続強化補助"
             "ノスフェラトゥ"
             "マギリフレクター"
+            "オートヒール"
+            "アストラルガーダー"
         );
     ];
     sh:property [


### PR DESCRIPTION
### 概要

LGロスヴァイセとその所属リリィ「北河原伊紀」「石上碧乙」「ロザリンデ・フリーデグンデ・フォン・オットー」「山田早緑」「小野木瑳都」「安井諒」を追加。

### 情報源

原作公式Twitter。
「山田早緑」「小野木瑳都」「安井諒」の所属クラスはアニメ「アサルトリリィ BOUQUET」第2話のクラス分け表より。

### チェック項目

この変更は
- [ ] 新しいクラスやプロパティ定義を追加する
- [ ] 既存のデータ構造やデータ規則の破壊的な変更を含む
- [x] 既存のRDF制約に違反しており、制約を緩和する必要がある：

用語の意味を私が正しく理解しているのか自信がないのですが、
石上碧乙のブーステッドスキルのために
constraints/Lily_Shape.ttlにおけるブーステッドスキルの制約を緩和（「オートヒール」を追加）しています。
また（現在使用者は判明していませんが）
「アストラルガーダー」（情報源：[電撃ホビーウェブの記事](https://hobby.dengeki.com/news/1076900/)）
をも追加しました。