### PR TITLE
舞台 御台場TSA全公演終了に伴うデータ更新

### DIFF
--- a/.rdflint/rdflint-suppress.yml
+++ b/.rdflint/rdflint-suppress.yml
@@ -233,6 +233,26 @@ RDFs/charm.rdf:
         - "Gunnfjödur"@en)'
   - key: com.github.imas.rdflint.validator.impl.notmatchedLanguageType
     level: INFO
+    line: '777'
+    column: '1'
+    subject: https://lily.fvhp.net/rdf/RDFs/detail/Naegling
+    predicate: https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#seriesName
+    object: '"Nægling"@en'
+    message: 'Data LanguageType not matched: lang is en, but Nægling (line: 777, col:
+        1, triple: https://lily.fvhp.net/rdf/RDFs/detail/Naegling - https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#seriesName
+        - "Nægling"@en)'
+  - key: com.github.imas.rdflint.validator.impl.notmatchedLanguageType
+    level: INFO
+    line: '779'
+    column: '1'
+    subject: https://lily.fvhp.net/rdf/RDFs/detail/Naegling
+    predicate: http://schema.org/name
+    object: '"Nægling"@en'
+    message: 'Data LanguageType not matched: lang is en, but Nægling (line: 779, col:
+        1, triple: https://lily.fvhp.net/rdf/RDFs/detail/Naegling - http://schema.org/name
+        - "Nægling"@en)'
+  - key: com.github.imas.rdflint.validator.impl.notmatchedLanguageType
+    level: INFO
     line: '977'
     column: '1'
     subject: https://lily.fvhp.net/rdf/RDFs/detail/Precieuse

--- a/RDFs/character.rdf
+++ b/RDFs/character.rdf
@@ -135,7 +135,7 @@
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">柴田茉莉</schema:name>
     <!-- <lily:resource rdf:resource=""/> -->
-    <lily:performIn rdf:resource="Assault_Lily_Odaiba_Jogakkou_Hen"/>
+    <lily:performIn rdf:resource="Assault_Lily_Odaiba_The_Singular_Ability"/>
   </lily:cast>
   <lily:additionalInformation xml:lang="ja">御台場女学校中等科に進学する直前に死去</lily:additionalInformation>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Character"/>

--- a/RDFs/character.rdf
+++ b/RDFs/character.rdf
@@ -91,9 +91,9 @@
   <!-- <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></foaf:age> -->
   <!-- <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:height> -->
   <!-- <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:weight> -->
-  <!-- <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay"></schema:birthDate> -->
+  <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-23</schema:birthDate>
   <lily:lifeStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dead</lily:lifeStatus>
-  <!-- <lily:killedIn xml:lang="ja"></lily:killedIn> -->
+  <lily:killedIn xml:lang="ja">中等科1年の時に病死</lily:killedIn>
   <!-- <lily:bloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:bloodType> -->
   <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
   <!-- <lily:color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary"></lily:color> -->
@@ -112,7 +112,7 @@
     <!-- <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:usedIn> -->
     <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
   <!-- </lily:charm> -->
-  <lily:garden rdf:datatype="http://www.w3.org/2001/XMLSchema#string">御台場女学校初等科</lily:garden>
+  <lily:garden rdf:datatype="http://www.w3.org/2001/XMLSchema#string">御台場女学校中等科</lily:garden>
   <!-- <lily:gardenDepartment rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:gardenDepartment> -->
   <!-- <lily:grade rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:grade> -->
   <!-- <lily:class rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:class> -->
@@ -128,16 +128,21 @@
     <lily:resource rdf:resource="Imamura_Yukari"/>
     <lily:additionalInformation xml:lang="ja">妹</lily:additionalInformation>
   </schema:sibling>
-  <!-- <lily:relationship rdf:parseType="Resource"> -->
-    <!-- <lily:resource rdf:resource=""/> -->
-    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
-  <!-- </lily:relationship> -->
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Hishida_Haru"/>
+    <lily:additionalInformation xml:lang="ja">幼馴染</lily:additionalInformation>
+    <lily:additionalInformation xml:lang="ja">「御台場を守る一番のリリィとなる」という夢を託す</lily:additionalInformation>
+  </lily:relationship>
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Yokoyama_Azusa"/>
+    <lily:additionalInformation xml:lang="ja">幼馴染</lily:additionalInformation>
+  </lily:relationship>
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">柴田茉莉</schema:name>
     <!-- <lily:resource rdf:resource=""/> -->
     <lily:performIn rdf:resource="Assault_Lily_Odaiba_The_Singular_Ability"/>
   </lily:cast>
-  <lily:additionalInformation xml:lang="ja">御台場女学校中等科に進学する直前に死去</lily:additionalInformation>
+  <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Character"/>
 </rdf:Description>
 

--- a/RDFs/character.rdf
+++ b/RDFs/character.rdf
@@ -87,7 +87,7 @@
   <schema:name xml:lang="ja">今村咲魅</schema:name>
   <schema:name xml:lang="en">Imamura Sakumi</schema:name>
   <lily:nameKana xml:lang="ja">いまむらさくみ</lily:nameKana>
-  <!-- <lily:anotherName xml:lang="ja"></lily:anotherName> -->
+  <lily:anotherName xml:lang="ja">夭折の天才リリィ</lily:anotherName>
   <!-- <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></foaf:age> -->
   <!-- <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:height> -->
   <!-- <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:weight> -->

--- a/RDFs/charm.rdf
+++ b/RDFs/charm.rdf
@@ -795,7 +795,7 @@
   <!-- <lily:requiredSkillerVal rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:requiredSkillerVal> -->
   <schema:manufacturer rdf:resource="Yggdrasill"/>
   <lily:user rdf:resource="Kawabata_Hotaru"/>
-  <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <lily:additionalInformation xml:lang="ja">円環の御手保持者向けCHARM</lily:additionalInformation>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Charm"/>
 </rdf:Description>
 

--- a/RDFs/charm.rdf
+++ b/RDFs/charm.rdf
@@ -743,12 +743,12 @@
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Charm"/>
 </rdf:Description>
 
-<rdf:Description rdf:about="Yaren_Grable">
+<rdf:Description rdf:about="Jarngreipr">
   <schema:productID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AC-25</schema:productID>
-  <lily:seriesName xml:lang="ja">ヤーレングレイブル</lily:seriesName>
-  <lily:seriesName xml:lang="en">Yaren Grable</lily:seriesName>
-  <schema:name xml:lang="ja">ヤーレングレイブル</schema:name>
-  <schema:name xml:lang="en">Yaren Grable</schema:name>
+  <lily:seriesName xml:lang="ja">ヤールングレイプル</lily:seriesName>
+  <lily:seriesName xml:lang="en">Jarngreipr</lily:seriesName>
+  <schema:name xml:lang="ja">ヤールングレイプル</schema:name>
+  <schema:name xml:lang="en">Jarngreipr</schema:name>
   <lily:generation rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">3</lily:generation>
   <!-- <lily:requiredSkillerVal rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:requiredSkillerVal> -->
   <schema:manufacturer rdf:resource="Yggdrasill"/>
@@ -771,12 +771,12 @@
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Charm"/>
 </rdf:Description>
 
-<rdf:Description rdf:about="Nailling">
+<rdf:Description rdf:about="Naegling">
   <schema:productID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AC-15</schema:productID>
   <lily:seriesName xml:lang="ja">ネイリング</lily:seriesName>
-  <lily:seriesName xml:lang="en">Nailling</lily:seriesName>
+  <lily:seriesName xml:lang="en">Nægling</lily:seriesName>
   <schema:name xml:lang="ja">ネイリング</schema:name>
-  <schema:name xml:lang="en">Nailling</schema:name>
+  <schema:name xml:lang="en">Nægling</schema:name>
   <lily:generation rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">2</lily:generation>
   <!-- <lily:requiredSkillerVal rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:requiredSkillerVal> -->
   <schema:manufacturer rdf:resource="Yggdrasill"/>

--- a/RDFs/charm.rdf
+++ b/RDFs/charm.rdf
@@ -1128,4 +1128,19 @@
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Charm"/>
 </rdf:Description>
 
+<rdf:Description rdf:about="Galateia">
+  <!-- <schema:productID rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></schema:productID> -->
+  <lily:seriesName xml:lang="ja">ガラテイア</lily:seriesName>
+  <lily:seriesName xml:lang="en">Galateia</lily:seriesName>
+  <schema:name xml:lang="ja">ガラテイア</schema:name>
+  <schema:name xml:lang="en">Galateia</schema:name>
+  <!-- <lily:generation rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal"></lily:generation> -->
+  <!-- <lily:requiredSkillerVal rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:requiredSkillerVal> -->
+  <schema:manufacturer rdf:resource="Vulcanus_Industry"/>
+  <lily:user rdf:resource="Hishida_Haru"/>
+  <lily:additionalInformation xml:lang="ja">ダミークリスタルコア搭載</lily:additionalInformation>
+  <lily:additionalInformation xml:lang="ja">「契約代行システム」実験機</lily:additionalInformation>
+  <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Charm"/>
+</rdf:Description>
+
 </rdf:RDF>

--- a/RDFs/lily_odaiba.rdf
+++ b/RDFs/lily_odaiba.rdf
@@ -104,7 +104,7 @@
     <lily:resource rdf:resource="http://ja.dbpedia.org/resource/石井陽菜"/>
     <lily:performIn rdf:resource="League_of_Gardens"/>
     <lily:performIn rdf:resource="The_Fateful_Gift"/>
-    <lily:performIn rdf:resource="Assault_Lily_Odaiba_Jogakkou_Hen"/>
+    <lily:performIn rdf:resource="Assault_Lily_Odaiba_The_Singular_Ability"/>
   </lily:cast>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
 </rdf:Description>
@@ -193,7 +193,7 @@
     <lily:resource rdf:resource="http://ja.dbpedia.org/resource/西葉瑞希"/>
     <lily:performIn rdf:resource="League_of_Gardens"/>
     <lily:performIn rdf:resource="The_Fateful_Gift"/>
-    <lily:performIn rdf:resource="Assault_Lily_Odaiba_Jogakkou_Hen"/>
+    <lily:performIn rdf:resource="Assault_Lily_Odaiba_The_Singular_Ability"/>
   </lily:cast>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
 </rdf:Description>
@@ -286,7 +286,7 @@
     <schema:name xml:lang="ja">野元空</schema:name>
     <lily:resource rdf:resource="https://www.wikidata.org/wiki/Q18999130"/>
     <lily:resource rdf:resource="http://ja.dbpedia.org/resource/野元空"/>
-    <lily:performIn rdf:resource="Assault_Lily_Odaiba_Jogakkou_Hen"/>
+    <lily:performIn rdf:resource="Assault_Lily_Odaiba_The_Singular_Ability"/>
   </lily:cast>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
 </rdf:Description>
@@ -363,7 +363,7 @@
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">広沢麻衣</schema:name>
     <lily:resource rdf:resource="https://www.wikidata.org/wiki/Q34856960"/>
-    <lily:performIn rdf:resource="Assault_Lily_Odaiba_Jogakkou_Hen"/>
+    <lily:performIn rdf:resource="Assault_Lily_Odaiba_The_Singular_Ability"/>
   </lily:cast>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
 </rdf:Description>
@@ -464,7 +464,7 @@
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">有沢澪風</schema:name>
     <lily:resource rdf:resource="https://www.wikidata.org/wiki/Q30933448"/>
-    <lily:performIn rdf:resource="Assault_Lily_Odaiba_Jogakkou_Hen"/>
+    <lily:performIn rdf:resource="Assault_Lily_Odaiba_The_Singular_Ability"/>
   </lily:cast>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
 </rdf:Description>
@@ -539,7 +539,7 @@
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">海乃るり</schema:name>
     <lily:resource rdf:resource="https://www.wikidata.org/wiki/Q54292702"/>
-    <lily:performIn rdf:resource="Assault_Lily_Odaiba_Jogakkou_Hen"/>
+    <lily:performIn rdf:resource="Assault_Lily_Odaiba_The_Singular_Ability"/>
   </lily:cast>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
 </rdf:Description>
@@ -630,7 +630,7 @@
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">春咲暖</schema:name>
     <lily:resource rdf:resource="https://www.wikidata.org/wiki/Q35172355"/>
-    <lily:performIn rdf:resource="Assault_Lily_Odaiba_Jogakkou_Hen"/>
+    <lily:performIn rdf:resource="Assault_Lily_Odaiba_The_Singular_Ability"/>
   </lily:cast>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
 </rdf:Description>
@@ -721,7 +721,7 @@
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">高辻麗</schema:name>
     <lily:resource rdf:resource="https://www.wikidata.org/wiki/Q56556215"/>
-    <lily:performIn rdf:resource="Assault_Lily_Odaiba_Jogakkou_Hen"/>
+    <lily:performIn rdf:resource="Assault_Lily_Odaiba_The_Singular_Ability"/>
   </lily:cast>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
 </rdf:Description>
@@ -817,7 +817,7 @@
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">長谷川里桃</schema:name>
     <lily:resource rdf:resource="https://www.wikidata.org/wiki/Q38279051"/>
-    <lily:performIn rdf:resource="Assault_Lily_Odaiba_Jogakkou_Hen"/>
+    <lily:performIn rdf:resource="Assault_Lily_Odaiba_The_Singular_Ability"/>
   </lily:cast>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
 </rdf:Description>
@@ -992,7 +992,7 @@
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">河内美里</schema:name>
     <lily:resource rdf:resource="https://www.wikidata.org/wiki/Q65272225"/>
-    <lily:performIn rdf:resource="Assault_Lily_Odaiba_Jogakkou_Hen"/>
+    <lily:performIn rdf:resource="Assault_Lily_Odaiba_The_Singular_Ability"/>
   </lily:cast>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
 </rdf:Description>
@@ -1263,7 +1263,7 @@
     <lily:resource rdf:resource="https://www.wikidata.org/wiki/Q56253675"/>
     <lily:performIn rdf:resource="League_of_Gardens"/>
     <lily:performIn rdf:resource="The_Fateful_Gift"/>
-    <lily:performIn rdf:resource="Assault_Lily_Odaiba_Jogakkou_Hen"/>
+    <lily:performIn rdf:resource="Assault_Lily_Odaiba_The_Singular_Ability"/>
   </lily:cast>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
 </rdf:Description>
@@ -1340,7 +1340,7 @@
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">白石まゆみ</schema:name>
     <!-- <lily:resource rdf:resource=""/> -->
-    <lily:performIn rdf:resource="Assault_Lily_Odaiba_Jogakkou_Hen"/>
+    <lily:performIn rdf:resource="Assault_Lily_Odaiba_The_Singular_Ability"/>
   </lily:cast>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
 </rdf:Description>
@@ -1435,7 +1435,7 @@
     <schema:name xml:lang="ja">野本ほたる</schema:name>
     <lily:resource rdf:resource="https://www.wikidata.org/wiki/Q11645500"/>
     <lily:resource rdf:resource="http://ja.dbpedia.org/resource/野本ほたる"/>
-    <lily:performIn rdf:resource="Assault_Lily_Odaiba_Jogakkou_Hen"/>
+    <lily:performIn rdf:resource="Assault_Lily_Odaiba_The_Singular_Ability"/>
   </lily:cast>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
 </rdf:Description>
@@ -1526,7 +1526,7 @@
     <schema:name xml:lang="ja">林田真尋</schema:name>
     <lily:resource rdf:resource="https://www.wikidata.org/wiki/Q19162226"/>
     <lily:resource rdf:resource="http://ja.dbpedia.org/resource/林田真尋"/>
-    <lily:performIn rdf:resource="Assault_Lily_Odaiba_Jogakkou_Hen"/>
+    <lily:performIn rdf:resource="Assault_Lily_Odaiba_The_Singular_Ability"/>
   </lily:cast>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Lily"/>
 </rdf:Description>

--- a/RDFs/lily_odaiba.rdf
+++ b/RDFs/lily_odaiba.rdf
@@ -238,7 +238,7 @@
   <lily:hobby_talent xml:lang="ja">サウナ</lily:hobby_talent>
   <lily:hobby_talent xml:lang="ja">ハーブティー</lily:hobby_talent>
   <!-- <lily:skillerVal rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:skillerVal> -->
-  <lily:rareSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">カリスマ</lily:rareSkill>
+  <lily:rareSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ラプラス</lily:rareSkill>
   <lily:subSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Awakening</lily:subSkill>
   <lily:isBoosted rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</lily:isBoosted>
   <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">リジェネレーター</lily:boostedSkill>

--- a/RDFs/lily_odaiba.rdf
+++ b/RDFs/lily_odaiba.rdf
@@ -66,7 +66,8 @@
   </lily:charm>
   <lily:charm rdf:parseType="Resource">
     <lily:resource rdf:resource="Hrunting"/>
-    <!-- <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:usedIn> -->
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ドール</lily:usedIn>
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">舞台御台場TSA</lily:usedIn>
     <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
   </lily:charm>
   <lily:charm rdf:parseType="Resource">
@@ -158,8 +159,9 @@
     <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
   </lily:charm>
   <lily:charm rdf:parseType="Resource">
-    <lily:resource rdf:resource="Nailling"/>
+    <lily:resource rdf:resource="Naegling"/>
     <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ドール</lily:usedIn>
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">舞台御台場TSA</lily:usedIn>
     <lily:additionalInformation xml:lang="ja">ユニーク機体</lily:additionalInformation>
   </lily:charm>
   <lily:charm rdf:parseType="Resource">
@@ -240,6 +242,7 @@
   <lily:charm rdf:parseType="Resource">
     <lily:resource rdf:resource="Vinst_Lilie"/>
     <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">舞台TFG</lily:usedIn>
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">舞台御台場TSA</lily:usedIn>
     <lily:additionalInformation xml:lang="ja">実験機</lily:additionalInformation>
   </lily:charm>
   <lily:charm rdf:parseType="Resource">
@@ -331,7 +334,7 @@
   <!-- <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:boostedSkill> -->
   <lily:charm rdf:parseType="Resource">
     <lily:resource rdf:resource="Beagonth_Seax"/>
-    <!-- <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:usedIn> -->
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">舞台御台場TSA</lily:usedIn>
     <lily:additionalInformation xml:lang="ja">試作機</lily:additionalInformation>
   </lily:charm>
   <lily:charm rdf:parseType="Resource">
@@ -408,7 +411,7 @@
   <!-- <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:boostedSkill> -->
   <lily:charm rdf:parseType="Resource">
     <lily:resource rdf:resource="Failnaught"/>
-    <!-- <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:usedIn> -->
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">舞台御台場TSA</lily:usedIn>
     <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
   </lily:charm>
   <lily:charm rdf:parseType="Resource">
@@ -507,7 +510,7 @@
   <!-- <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:boostedSkill> -->
   <lily:charm rdf:parseType="Resource">
     <lily:resource rdf:resource="Hildr"/>
-    <!-- <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:usedIn> -->
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">舞台御台場TSA</lily:usedIn>
     <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
   </lily:charm>
   <lily:charm rdf:parseType="Resource">
@@ -586,8 +589,8 @@
   <!-- <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:boostedSkill> -->
   <lily:charm rdf:parseType="Resource">
     <lily:resource rdf:resource="Gray_Side"/>
-    <!-- <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:usedIn> -->
-    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">舞台御台場TSA</lily:usedIn>
+    <lily:additionalInformation xml:lang="ja">先行試作機</lily:additionalInformation>
   </lily:charm>
   <lily:charm rdf:parseType="Resource">
     <lily:resource rdf:resource="Yotunschwert"/>
@@ -677,7 +680,7 @@
   <!-- <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:boostedSkill> -->
   <lily:charm rdf:parseType="Resource">
     <lily:resource rdf:resource="Keraunos"/>
-    <!-- <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:usedIn> -->
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">舞台御台場TSA</lily:usedIn>
     <lily:additionalInformation xml:lang="ja">ユニーク機体</lily:additionalInformation>
   </lily:charm>
   <lily:charm rdf:parseType="Resource">
@@ -764,8 +767,8 @@
   <lily:isBoosted rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</lily:isBoosted>
   <!-- <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:boostedSkill> -->
   <lily:charm rdf:parseType="Resource">
-    <lily:resource rdf:resource="Yaren_Grable"/>
-    <!-- <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:usedIn> -->
+    <lily:resource rdf:resource="Jarngreipr"/>
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">舞台御台場TSA</lily:usedIn>
     <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
   </lily:charm>
   <lily:charm rdf:parseType="Resource">
@@ -949,7 +952,7 @@
   <!-- <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:boostedSkill> -->
   <lily:charm rdf:parseType="Resource">
     <lily:resource rdf:resource="Brionac"/>
-    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">御台場舞台</lily:usedIn>
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">舞台御台場TSA</lily:usedIn>
     <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
   </lily:charm>
   <lily:charm rdf:parseType="Resource">
@@ -1195,7 +1198,7 @@
   </lily:charm>
   <lily:charm rdf:parseType="Resource">
     <lily:resource rdf:resource="Hrotti"/>
-    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">御台場舞台</lily:usedIn>
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">舞台御台場TSA</lily:usedIn>
     <lily:additionalInformation xml:lang="ja">ユニーク機体</lily:additionalInformation>
   </lily:charm>
   <lily:charm rdf:parseType="Resource">
@@ -1304,7 +1307,7 @@
   <!-- <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:boostedSkill> -->
   <lily:charm rdf:parseType="Resource">
     <lily:resource rdf:resource="Kuruzzi"/>
-    <!-- <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:usedIn> -->
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">舞台御台場TSA</lily:usedIn>
     <lily:additionalInformation xml:lang="ja">試験機</lily:additionalInformation>
   </lily:charm>
   <lily:charm rdf:parseType="Resource">
@@ -1386,7 +1389,7 @@
   </lily:charm>
   <lily:charm rdf:parseType="Resource">
     <lily:resource rdf:resource="Tyrfing_type_R"/>
-    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">御台場舞台</lily:usedIn>
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">舞台御台場TSA</lily:usedIn>
     <lily:additionalInformation xml:lang="ja">試験機</lily:additionalInformation>
   </lily:charm>
   <lily:charm rdf:parseType="Resource">
@@ -1476,7 +1479,7 @@
   <!-- <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:boostedSkill> -->
   <lily:charm rdf:parseType="Resource">
     <lily:resource rdf:resource="Caladbolg"/>
-    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">御台場舞台</lily:usedIn>
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">舞台御台場TSA</lily:usedIn>
     <lily:additionalInformation xml:lang="ja">ユニーク機体</lily:additionalInformation>
   </lily:charm>
   <lily:charm rdf:parseType="Resource">

--- a/RDFs/lily_odaiba.rdf
+++ b/RDFs/lily_odaiba.rdf
@@ -1326,7 +1326,7 @@
   <!-- <lily:notGood xml:lang="ja"></lily:notGood> -->
   <!-- <lily:hobby_talent xml:lang="ja"></lily:hobby_talent> -->
   <!-- <lily:skillerVal rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:skillerVal> -->
-  <lily:rareSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">カリスマ</lily:rareSkill>
+  <lily:rareSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ラプラス</lily:rareSkill>
   <!-- <lily:subSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:subSkill> -->
   <lily:isBoosted rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</lily:isBoosted>
   <!-- <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:boostedSkill> -->
@@ -1359,11 +1359,12 @@
   <!-- </schema:sibling> -->
   <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Kawanabe_Nazuna"/>
-    <lily:additionalInformation xml:lang="ja">嫉妬</lily:additionalInformation>
+    <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation>
+    <lily:additionalInformation xml:lang="ja">嫉妬の対象</lily:additionalInformation>
   </lily:relationship>
   <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Hishida_Haru"/>
-    <lily:additionalInformation xml:lang="ja">憧れ</lily:additionalInformation>
+    <lily:additionalInformation xml:lang="ja">憧れの先輩</lily:additionalInformation>
   </lily:relationship>
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">白石まゆみ</schema:name>

--- a/RDFs/lily_odaiba.rdf
+++ b/RDFs/lily_odaiba.rdf
@@ -189,6 +189,10 @@
     <lily:resource rdf:resource="Nagasawa_Yuki"/>
     <lily:additionalInformation xml:lang="ja">姉のような存在</lily:additionalInformation>
   </lily:relationship>
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Fujita_Asagao"/>
+    <lily:additionalInformation xml:lang="ja">実力を認める仲</lily:additionalInformation>
+  </lily:relationship>
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">西葉瑞希</schema:name>
     <lily:resource rdf:resource="https://www.wikidata.org/wiki/Q98734254"/>

--- a/RDFs/lily_odaiba.rdf
+++ b/RDFs/lily_odaiba.rdf
@@ -1493,8 +1493,8 @@
   <!-- <lily:bloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:bloodType> -->
   <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
   <!-- <lily:color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary"></lily:color> -->
-  <!-- <schema:birthPlace xml:lang="ja"></schema:birthPlace> -->
-  <!-- <schema:birthPlace xml:lang="en"></schema:birthPlace> -->
+  <schema:birthPlace xml:lang="ja">東京都</schema:birthPlace>
+  <schema:birthPlace xml:lang="en">Tokyo</schema:birthPlace>
   <lily:favorite xml:lang="ja">フクロウ</lily:favorite>
   <!-- <lily:notGood xml:lang="ja"></lily:notGood> -->
   <!-- <lily:hobby_talent xml:lang="ja"></lily:hobby_talent> -->
@@ -1539,10 +1539,11 @@
     <lily:resource rdf:resource="Imamura_Yukari"/>
     <lily:additionalInformation xml:lang="ja">幼馴染 (今は疎遠)</lily:additionalInformation>
   </lily:relationship>
-  <!-- <lily:relationship rdf:parseType="Resource"> -->
-    <!-- <lily:resource rdf:resource="Imamura_Sakumi"/> -->
-    <!-- <lily:additionalInformation xml:lang="ja">幼馴染</lily:additionalInformation> -->
-  <!-- </lily:relationship> -->
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Imamura_Sakumi"/>
+    <lily:additionalInformation xml:lang="ja">幼馴染</lily:additionalInformation>
+    <lily:additionalInformation xml:lang="ja">「御台場を守る一番のリリィとなる」と約束した</lily:additionalInformation>
+  </lily:relationship>
   <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Tsukioka_Momiji"/>
     <lily:additionalInformation xml:lang="ja">固い絆</lily:additionalInformation>
@@ -1550,6 +1551,14 @@
   <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Kawamura_Yuzuriha"/>
     <lily:additionalInformation xml:lang="ja">固い絆</lily:additionalInformation>
+  </lily:relationship>
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Kawanabe_Nazuna"/>
+    <lily:additionalInformation xml:lang="ja">かわいがっている後輩</lily:additionalInformation>
+  </lily:relationship>
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Suzuki_Chinami"/>
+    <lily:additionalInformation xml:lang="ja">憧れられている後輩</lily:additionalInformation>
   </lily:relationship>
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">林田真尋</schema:name>

--- a/RDFs/lily_odaiba.rdf
+++ b/RDFs/lily_odaiba.rdf
@@ -1398,8 +1398,8 @@
   <!-- <lily:bloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:bloodType> -->
   <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
   <!-- <lily:color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary"></lily:color> -->
-  <!-- <schema:birthPlace xml:lang="ja"></schema:birthPlace> -->
-  <!-- <schema:birthPlace xml:lang="en"></schema:birthPlace> -->
+  <schema:birthPlace xml:lang="ja">東京都</schema:birthPlace>
+  <schema:birthPlace xml:lang="en">Tokyo</schema:birthPlace>
   <lily:favorite xml:lang="ja">犬</lily:favorite>
   <!-- <lily:notGood xml:lang="ja"></lily:notGood> -->
   <!-- <lily:hobby_talent xml:lang="ja"></lily:hobby_talent> -->
@@ -1448,10 +1448,10 @@
     <lily:resource rdf:resource="Imamura_Yukari"/>
     <lily:additionalInformation xml:lang="ja">幼馴染</lily:additionalInformation>
   </lily:relationship>
-  <!-- <lily:relationship rdf:parseType="Resource"> -->
-    <!-- <lily:resource rdf:resource="Imamura_Sakumi"/> -->
-    <!-- <lily:additionalInformation xml:lang="ja">幼馴染</lily:additionalInformation> -->
-  <!-- </lily:relationship> -->
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Imamura_Sakumi"/>
+    <lily:additionalInformation xml:lang="ja">幼馴染</lily:additionalInformation>
+  </lily:relationship>
   <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Tsukioka_Momiji"/>
     <lily:additionalInformation xml:lang="ja">固い絆</lily:additionalInformation>

--- a/RDFs/lily_odaiba.rdf
+++ b/RDFs/lily_odaiba.rdf
@@ -544,6 +544,10 @@
     <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
   <!-- </schema:sibling> -->
   <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Fujita_Asagao"/>
+    <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation>
+  </lily:relationship>
+  <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Hayami_Katsura"/>
     <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation>
   </lily:relationship>
@@ -629,6 +633,7 @@
   <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Funada_Ui"/>
     <lily:additionalInformation xml:lang="ja">幼少期から尊敬</lily:additionalInformation>
+    <lily:additionalInformation xml:lang="ja">実力を認める仲</lily:additionalInformation>
   </lily:relationship>
   <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Banshoya_Ena"/>
@@ -727,7 +732,7 @@
   </lily:relationship>
   <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Yokoyama_Azusa"/>
-    <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation>
+    <lily:additionalInformation xml:lang="ja">幼馴染</lily:additionalInformation>
   </lily:relationship>
   <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Kawanabe_Nazuna"/>

--- a/RDFs/lily_odaiba.rdf
+++ b/RDFs/lily_odaiba.rdf
@@ -965,7 +965,7 @@
   <lily:favorite xml:lang="ja">ウサギ (特にロップイヤー)</lily:favorite>
   <lily:favorite xml:lang="ja">カエル</lily:favorite>
   <!-- <lily:notGood xml:lang="ja"></lily:notGood> -->
-  <lily:hobby_talent xml:lang="ja">足が速い</lily:hobby_talent>
+  <lily:hobby_talent xml:lang="ja">走ること</lily:hobby_talent>
   <!-- <lily:skillerVal rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:skillerVal> -->
   <lily:rareSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ファンタズム</lily:rareSkill>
   <!-- <lily:subSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:subSkill> -->
@@ -1012,6 +1012,10 @@
   <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Takehisa_Nakaba"/>
     <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation>
+  </lily:relationship>
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Hishida_Haru"/>
+    <lily:additionalInformation xml:lang="ja">かわいがってくれる先輩</lily:additionalInformation>
   </lily:relationship>
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">河内美里</schema:name>

--- a/RDFs/lily_odaiba.rdf
+++ b/RDFs/lily_odaiba.rdf
@@ -441,6 +441,10 @@
     <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
   <!-- </schema:sibling> -->
   <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Fujita_Asagao"/>
+    <lily:additionalInformation xml:lang="ja">憧れの先輩</lily:additionalInformation>
+  </lily:relationship>
+  <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Shiba_Tomoshibi"/>
     <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation>
   </lily:relationship>
@@ -528,7 +532,7 @@
   <!-- <lily:class rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:class> -->
   <!-- <lily:gardenJobTitle xml:lang="ja"></lily:gardenJobTitle> -->
   <lily:legion rdf:resource="Hronesness"/>
-  <!-- <lily:legionJobTitle rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:legionJobTitle> -->
+  <lily:legionJobTitle rdf:datatype="http://www.w3.org/2001/XMLSchema#string">司令塔</lily:legionJobTitle>
   <lily:position rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AZ</lily:position>
   <lily:position rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TZ</lily:position>
   <!-- <lily:pastLegion rdf:resource=""/> -->
@@ -542,6 +546,10 @@
   <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Hayami_Katsura"/>
     <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation>
+  </lily:relationship>
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Imamura_Yukari"/>
+    <lily:additionalInformation xml:lang="ja">気にかけている後輩</lily:additionalInformation>
   </lily:relationship>
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">海乃るり</schema:name>
@@ -709,6 +717,10 @@
     <lily:resource rdf:resource="Imamura_Sakumi"/>
     <lily:additionalInformation xml:lang="ja">姉</lily:additionalInformation>
   </schema:sibling>
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Igusa_Subaru"/>
+    <lily:additionalInformation xml:lang="ja">道を示してくれる先輩</lily:additionalInformation>
+  </lily:relationship>
   <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Kozue_West"/>
     <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation>

--- a/RDFs/lily_odaiba.rdf
+++ b/RDFs/lily_odaiba.rdf
@@ -236,7 +236,7 @@
   <lily:notGood xml:lang="ja">GEHENA</lily:notGood>
   <lily:hobby_talent xml:lang="ja">押し花</lily:hobby_talent>
   <lily:hobby_talent xml:lang="ja">サウナ</lily:hobby_talent>
-  <lily:hobby_talent xml:lang="ja">ハーブティ</lily:hobby_talent>
+  <lily:hobby_talent xml:lang="ja">ハーブティー</lily:hobby_talent>
   <!-- <lily:skillerVal rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:skillerVal> -->
   <lily:rareSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">カリスマ</lily:rareSkill>
   <lily:subSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Awakening</lily:subSkill>
@@ -281,7 +281,7 @@
   </lily:relationship>
   <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Kawanabe_Nazuna"/>
-    <lily:additionalInformation xml:lang="ja">ハーブティ好き同士</lily:additionalInformation>
+    <lily:additionalInformation xml:lang="ja">ハーブティー好き同士</lily:additionalInformation>
   </lily:relationship>
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">富田麻帆</schema:name>
@@ -944,7 +944,7 @@
   <!-- <lily:color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary"></lily:color> -->
   <!-- <schema:birthPlace xml:lang="ja"></schema:birthPlace> -->
   <!-- <schema:birthPlace xml:lang="en"></schema:birthPlace> -->
-  <lily:favorite xml:lang="ja">ハーブティー</lily:favorite>
+  <lily:favorite xml:lang="ja">ハーブティーー</lily:favorite>
   <lily:favorite xml:lang="ja">ウサギ (特にロップイヤー)</lily:favorite>
   <lily:favorite xml:lang="ja">カエル</lily:favorite>
   <!-- <lily:notGood xml:lang="ja"></lily:notGood> -->
@@ -990,7 +990,7 @@
   </lily:relationship>
   <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Shiba_Tomoshibi"/>
-    <lily:additionalInformation xml:lang="ja">ハーブティ好き同士</lily:additionalInformation>
+    <lily:additionalInformation xml:lang="ja">ハーブティー好き同士</lily:additionalInformation>
   </lily:relationship>
   <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Takehisa_Nakaba"/>

--- a/RDFs/lily_odaiba.rdf
+++ b/RDFs/lily_odaiba.rdf
@@ -822,10 +822,10 @@
     <lily:resource rdf:resource="Funada_Ui"/>
     <lily:additionalInformation xml:lang="ja">妹のような存在</lily:additionalInformation>
   </lily:relationship>
-  <!-- <lily:relationship rdf:parseType="Resource"> -->
-    <!-- <lily:resource rdf:resource="Yamazaki_Meika"/> -->
-    <!-- <lily:additionalInformation xml:lang="ja">幕張奪還戦で共闘</lily:additionalInformation> -->
-  <!-- </lily:relationship> -->
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Yamazaki_Meika"/>
+    <lily:additionalInformation xml:lang="ja">幕張奪還戦で共闘</lily:additionalInformation>
+  </lily:relationship>
   <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Murakami_Tokiwa"/>
     <lily:additionalInformation xml:lang="ja">幕張奪還戦で共闘</lily:additionalInformation>
@@ -836,7 +836,7 @@
   </lily:relationship>
   <lily:relationship rdf:parseType="Resource">
     <lily:resource rdf:resource="Mashima_Moyu"/>
-    <lily:additionalInformation xml:lang="ja">ロネスネスに紹介</lily:additionalInformation>
+    <lily:additionalInformation xml:lang="ja">アーセナルとしてロネスネスに紹介</lily:additionalInformation>
   </lily:relationship>
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">長谷川里桃</schema:name>

--- a/RDFs/lily_odaiba.rdf
+++ b/RDFs/lily_odaiba.rdf
@@ -1509,6 +1509,11 @@
     <lily:additionalInformation xml:lang="ja">ユニーク機体</lily:additionalInformation>
   </lily:charm>
   <lily:charm rdf:parseType="Resource">
+    <lily:resource rdf:resource="Galateia"/>
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">舞台御台場TSA</lily:usedIn>
+    <lily:additionalInformation xml:lang="ja">一時的に使用</lily:additionalInformation>
+  </lily:charm>
+  <lily:charm rdf:parseType="Resource">
     <lily:resource rdf:resource="Yotunschwert"/>
     <!-- <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:usedIn> -->
     <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->

--- a/RDFs/lily_odaiba.rdf
+++ b/RDFs/lily_odaiba.rdf
@@ -363,10 +363,10 @@
     <!-- <lily:resource rdf:resource=""/> -->
     <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
   <!-- </schema:sibling> -->
-  <!-- <lily:relationship rdf:parseType="Resource"> -->
-    <!-- <lily:resource rdf:resource=""/> -->
-    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
-  <!-- </lily:relationship> -->
+  <lily:relationship rdf:parseType="Resource">
+    <lily:resource rdf:resource="Funada_Kiito"/>
+    <lily:additionalInformation xml:lang="ja">友人</lily:additionalInformation>
+  </lily:relationship>
   <lily:cast rdf:parseType="Resource">
     <schema:name xml:lang="ja">広沢麻衣</schema:name>
     <lily:resource rdf:resource="https://www.wikidata.org/wiki/Q34856960"/>

--- a/RDFs/lily_yurigaoka.rdf
+++ b/RDFs/lily_yurigaoka.rdf
@@ -3739,7 +3739,7 @@
   <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マギリフレクター</lily:boostedSkill>
   <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エンハンスメント</lily:boostedSkill>
   <lily:charm rdf:parseType="Resource">
-    <lily:resource rdf:resource="Yaren_Grable"/>
+    <lily:resource rdf:resource="Jarngreipr"/>
     <!-- <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:usedIn> -->
     <lily:additionalInformation xml:lang="ja">試作機</lily:additionalInformation>
   </lily:charm>

--- a/RDFs/media_play.rdf
+++ b/RDFs/media_play.rdf
@@ -1564,7 +1564,7 @@
     <schema:name xml:lang="ja">小野瀬みらい</schema:name>
     <lily:resource rdf:resource="https://www.wikidata.org/wiki/Q16769880"/>
     <lily:resource rdf:resource="http://ja.dbpedia.org/resource/小野瀬みらい"/>
-    <lily:performAs rdf:resource="Nakahara_Mary_Tomoyo"/>
+    <lily:performAs rdf:resource="Nakahara_Meary_Tomoyo"/>
     <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
   </lily:cast>
   <!-- <schema:abstract xml:lang="ja"></schema:abstract> -->

--- a/RDFs/media_play.rdf
+++ b/RDFs/media_play.rdf
@@ -1428,10 +1428,10 @@
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Play"/>
 </rdf:Description>
 
-<rdf:Description rdf:about="Assault_Lily_Odaiba_Jogakkou_Hen">
+<rdf:Description rdf:about="Assault_Lily_Odaiba_The_Singular_Ability">
   <lily:genre xml:lang="ja">舞台</lily:genre>
   <schema:name xml:lang="ja">舞台アサルトリリィ―御台場女学校編― The Singular Ability</schema:name>
-  <schema:alternateName xml:lang="ja">御台場舞台</schema:alternateName>
+  <schema:alternateName xml:lang="ja">舞台御台場TSA</schema:alternateName>
   <schema:inLanguage rdf:datatype="http://www.w3.org/2001/XMLSchema#language">ja-JP</schema:inLanguage>
   <schema:location rdf:datatype="http://www.w3.org/2001/XMLSchema#string">紀伊國屋ホール</schema:location>
   <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-08-20</schema:startDate>

--- a/RDFs/teacher_odaiba.rdf
+++ b/RDFs/teacher_odaiba.rdf
@@ -93,19 +93,19 @@
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Teacher"/>
 </rdf:Description>
 
-<rdf:Description rdf:about="Nakahara_Mary_Tomoyo">
+<rdf:Description rdf:about="Nakahara_Meary_Tomoyo">
   <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">中原・メアリィ・倫夜</rdfs:label>
   <schema:familyName xml:lang="ja">中原</schema:familyName>
   <schema:familyName xml:lang="en">Nakahara</schema:familyName>
   <lily:familyNameKana xml:lang="ja">なかはら</lily:familyNameKana>
   <schema:additionalName xml:lang="ja">メアリィ</schema:additionalName>
-  <schema:additionalName xml:lang="en">Mary</schema:additionalName>
+  <schema:additionalName xml:lang="en">Meary</schema:additionalName>
   <lily:additionalNameKana xml:lang="ja">めありぃ</lily:additionalNameKana>
   <schema:givenName xml:lang="ja">倫夜</schema:givenName>
   <schema:givenName xml:lang="en">Tomoyo</schema:givenName>
   <lily:givenNameKana xml:lang="ja">ともよ</lily:givenNameKana>
   <schema:name xml:lang="ja">中原・メアリィ・倫夜</schema:name>
-  <schema:name xml:lang="en">Nakahara Mary Tomoyo</schema:name>
+  <schema:name xml:lang="en">Nakahara Meary Tomoyo</schema:name>
   <lily:nameKana xml:lang="ja">なかはら・めありぃ・ともよ</lily:nameKana>
   <!-- <lily:anotherName xml:lang="ja"></lily:anotherName> -->
   <!-- <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></foaf:age> -->

--- a/RDFs/teacher_odaiba.rdf
+++ b/RDFs/teacher_odaiba.rdf
@@ -156,7 +156,7 @@
     <schema:name xml:lang="ja">小野瀬みらい</schema:name>
     <lily:resource rdf:resource="https://www.wikidata.org/wiki/Q16769880"/>
     <lily:resource rdf:resource="http://ja.dbpedia.org/resource/小野瀬みらい"/>
-    <lily:performIn rdf:resource="Assault_Lily_Odaiba_Jogakkou_Hen"/>
+    <lily:performIn rdf:resource="Assault_Lily_Odaiba_The_Singular_Ability"/>
   </lily:cast>
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Teacher"/>
 </rdf:Description>

--- a/constraints/Lily_Shape.ttl
+++ b/constraints/Lily_Shape.ttl
@@ -224,6 +224,7 @@ lily-shape:lilyShape a sh:NodeShape;
             "この世の理"
             "フェイズトランセンデンス"
             "カリスマ"
+            "ラプラス"
             "未覚醒"
         );
     ];

--- a/constraints/Lily_Shape.ttl
+++ b/constraints/Lily_Shape.ttl
@@ -17,7 +17,7 @@ lily-shape:lily-charmShape a sh:NodeShape;
 lily-shape:lily-relationshipShape a sh:NodeShape;
     sh:property [
         sh:path lily:resource ;
-        sh:class lily:Lily ;
+        sh:class lily:Character ;
         sh:minCount 1 ;
     ] ;
     sh:property [


### PR DESCRIPTION
### 概要

舞台「アサルトリリィ 御台場女学校編 The Singular Ability」が全公演終了したことに伴い、舞台や付随して行われた展示などで判明した情報を反映します。

### 情報源

- 舞台 御台場TSA公演
- 公演パンフレット
- アサルトリリィPOP UP SHOP -御台場女学校編- での展示

### チェック項目

この変更は
- [ ] 新しいクラスやプロパティ定義を追加する
- [ ] 既存のデータ構造やデータ規則の破壊的な変更を含む
- [x] 既存のRDF制約に違反しており、制約を緩和する必要がある

### 特記事項

RDF制約を一部緩和しました。
これに伴い、今まで禁止されていた `lily:Lily` の人間関係における `lily:Character` への参照が許容されます。
実際に今回の更新で菱田治および横山梓から今村咲魅への「幼馴染」という関係を有効化しています。