### PR TITLE
道川深顯、黒十字マディック隊の追加

### DIFF
--- a/IRIs/lily_schema.ttl
+++ b/IRIs/lily_schema.ttl
@@ -25,6 +25,11 @@ lily:Lily                       a   rdfs:Class ;
     rdfs:label                      "リリィ"@ja ;
     rdfs:subClassOf                 lily:Character .
 
+lily:Madec                      a   rdfs:Class ;
+    rdfs:comment                    "マディックを表すクラス" ;
+    rdfs:label                      "マディック"@ja ;
+    rdfs:subClassOf                 lily:Character .
+
 lily:Teacher                    a   rdfs:Class ;
     rdfs:comment                    "教導官を表すクラス" ;
     rdfs:label                      "教導官"@ja ;

--- a/RDFs/character.rdf
+++ b/RDFs/character.rdf
@@ -215,4 +215,71 @@
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Character"/>
 </rdf:Description>
 
+<rdf:Description rdf:about="Michikawa_Miaki">
+  <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">道川深顯</rdfs:label>
+  <schema:familyName xml:lang="ja">道川</schema:familyName>
+  <schema:familyName xml:lang="en">Michikawa</schema:familyName>
+  <lily:familyNameKana xml:lang="ja">みちかわ</lily:familyNameKana>
+  <!-- <schema:additionalName xml:lang="ja"></schema:additionalName> -->
+  <!-- <schema:additionalName xml:lang="en"></schema:additionalName> -->
+  <!-- <lily:additionalNameKana xml:lang="ja"></lily:additionalNameKana> -->
+  <schema:givenName xml:lang="ja">深顯</schema:givenName>
+  <schema:givenName xml:lang="en">Miaki	</schema:givenName>
+  <lily:givenNameKana xml:lang="ja">みあき</lily:givenNameKana>
+  <schema:name xml:lang="ja">道川深顯</schema:name>
+  <schema:name xml:lang="en">Michikawa Miaki</schema:name>
+  <lily:nameKana xml:lang="ja">みちかわみあき</lily:nameKana>
+  <lily:anotherName xml:lang="ja">夜釣りの魔術師</lily:anotherName>
+  <!-- <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></foaf:age> -->
+  <!-- <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:height> -->
+  <!-- <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float"></schema:weight> -->
+  <!-- <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay"></schema:birthDate> -->
+  <lily:lifeStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alive</lily:lifeStatus>
+  <!-- <lily:killedIn xml:lang="ja"></lily:killedIn> -->
+  <!-- <lily:bloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:bloodType> -->
+  <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
+  <!-- <lily:color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary"></lily:color> -->
+  <!-- <schema:birthPlace xml:lang="ja"></schema:birthPlace> -->
+  <!-- <schema:birthPlace xml:lang="en"></schema:birthPlace> -->
+  <!-- <lily:favorite xml:lang="ja"></lily:favorite> -->
+  <!-- <lily:notGood xml:lang="ja"></lily:notGood> -->
+  <!-- <lily:hobby_talent xml:lang="ja"></lily:hobby_talent> -->
+  <!-- <lily:skillerVal rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:skillerVal> -->
+  <!-- <lily:rareSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:rareSkill>
+  <!-- <lily:subSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:subSkill> -->
+  <lily:isBoosted rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</lily:isBoosted>
+  <!-- <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:boostedSkill> -->
+  <lily:charm rdf:parseType="Resource">
+    <lily:resource rdf:resource="Unknown_Named_Charm"/>
+    <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ラスバレ</lily:usedIn>
+    <lily:additionalInformation xml:lang="ja">試作機</lily:additionalInformation>
+  </lily:charm>
+  <lily:garden rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シエルリント女学薗</lily:garden>
+  <!-- <lily:gardenDepartment rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:gardenDepartment> -->
+  <!-- <lily:grade rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:grade> -->
+  <!-- <lily:class rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:class> -->
+  <!-- <lily:gardenJobTitle xml:lang="ja"></lily:gardenJobTitle> -->
+  <lily:legion rdf:resource="Schwarzes_Kreuz_Medic"/>
+  <lily:legionJobTitle rdf:datatype="http://www.w3.org/2001/XMLSchema#string">隊長</lily:legionJobTitle>
+  <!-- <lily:position rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:position> -->
+  <!-- <lily:pastLegion rdf:resource=""/> -->
+  <!-- <lily:taskforce rdf:resource=""/> -->
+  <!-- <lily:roomMate rdf:resource=""/> -->
+  <!-- <schema:parent rdf:resource=""/> -->
+  <!-- <schema:sibling rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <!-- </schema:sibling> -->
+  <!-- <lily:relationship rdf:parseType="Resource"> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <!-- </lily:relationship> -->
+  <!-- <lily:cast rdf:parseType="Resource"> -->
+    <!-- <schema:name xml:lang="ja"></schema:name> -->
+    <!-- <lily:resource rdf:resource=""/> -->
+    <!-- <lily:performIn rdf:resource=""/> -->
+  <!-- </lily:cast> -->
+  <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Character"/>
+</rdf:Description>
+
 </rdf:RDF>

--- a/RDFs/character.rdf
+++ b/RDFs/character.rdf
@@ -245,7 +245,7 @@
   <!-- <lily:notGood xml:lang="ja"></lily:notGood> -->
   <!-- <lily:hobby_talent xml:lang="ja"></lily:hobby_talent> -->
   <!-- <lily:skillerVal rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:skillerVal> -->
-  <!-- <lily:rareSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:rareSkill>
+  <!-- <lily:rareSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:rareSkill> -->
   <!-- <lily:subSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:subSkill> -->
   <lily:isBoosted rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</lily:isBoosted>
   <!-- <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:boostedSkill> -->

--- a/RDFs/character.rdf
+++ b/RDFs/character.rdf
@@ -224,7 +224,7 @@
   <!-- <schema:additionalName xml:lang="en"></schema:additionalName> -->
   <!-- <lily:additionalNameKana xml:lang="ja"></lily:additionalNameKana> -->
   <schema:givenName xml:lang="ja">深顯</schema:givenName>
-  <schema:givenName xml:lang="en">Miaki	</schema:givenName>
+  <schema:givenName xml:lang="en">Miaki</schema:givenName>
   <lily:givenNameKana xml:lang="ja">みあき</lily:givenNameKana>
   <schema:name xml:lang="ja">道川深顯</schema:name>
   <schema:name xml:lang="en">Michikawa Miaki</schema:name>

--- a/RDFs/character.rdf
+++ b/RDFs/character.rdf
@@ -250,7 +250,7 @@
   <lily:isBoosted rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</lily:isBoosted>
   <!-- <lily:boostedSkill rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:boostedSkill> -->
   <lily:charm rdf:parseType="Resource">
-    <lily:resource rdf:resource="Unknown_Named_Charm"/>
+    <lily:resource rdf:resource="Unknown_Named_Charm_2"/>
     <lily:usedIn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ラスバレ</lily:usedIn>
     <lily:additionalInformation xml:lang="ja">試作機</lily:additionalInformation>
   </lily:charm>
@@ -259,11 +259,11 @@
   <!-- <lily:grade rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:grade> -->
   <!-- <lily:class rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:class> -->
   <!-- <lily:gardenJobTitle xml:lang="ja"></lily:gardenJobTitle> -->
-  <lily:legion rdf:resource="Schwarzes_Kreuz_Medic"/>
-  <lily:legionJobTitle rdf:datatype="http://www.w3.org/2001/XMLSchema#string">隊長</lily:legionJobTitle>
+  <!-- <lily:legion rdf:resource=""/> -->
+  <!-- <lily:legionJobTitle rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:legionJobTitle> -->
   <!-- <lily:position rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:position> -->
   <!-- <lily:pastLegion rdf:resource=""/> -->
-  <!-- <lily:taskforce rdf:resource=""/> -->
+  <lily:taskforce rdf:resource="Schwarzes_Kreuz_Madec"/>
   <!-- <lily:roomMate rdf:resource=""/> -->
   <!-- <schema:parent rdf:resource=""/> -->
   <!-- <schema:sibling rdf:parseType="Resource"> -->
@@ -279,7 +279,7 @@
     <!-- <lily:resource rdf:resource=""/> -->
     <!-- <lily:performIn rdf:resource=""/> -->
   <!-- </lily:cast> -->
-  <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Character"/>
+  <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Madec"/>
 </rdf:Description>
 
 </rdf:RDF>

--- a/RDFs/charm.rdf
+++ b/RDFs/charm.rdf
@@ -21,6 +21,19 @@
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Charm"/>
 </rdf:Description>
 
+<rdf:Description rdf:about="Unknown_Named_Charm_2">
+  <!-- <schema:productID rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></schema:productID> -->
+  <lily:seriesName xml:lang="ja">CHARM名称不明</lily:seriesName>
+  <lily:seriesName xml:lang="en">Unknown Named CHARM</lily:seriesName>
+  <schema:name xml:lang="ja">CHARM名称不明</schema:name>
+  <schema:name xml:lang="en">Unknown Named CHARM</schema:name>
+  <!-- <lily:generation rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal"></lily:generation> -->
+  <!-- <schema:manufacturer rdf:resource=""/> -->
+  <lily:user rdf:resource="Michikawa_Miaki"/>
+  <!-- <lily:additionalInformation xml:lang="ja"></lily:additionalInformation> -->
+  <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Charm"/>
+</rdf:Description>
+
 <rdf:Description rdf:about="First_Generation_Charm">
   <!-- <schema:productID rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></schema:productID> -->
   <lily:seriesName xml:lang="ja">第1世代CHARM</lily:seriesName>

--- a/RDFs/legion.rdf
+++ b/RDFs/legion.rdf
@@ -795,18 +795,4 @@
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Legion"/>
 </rdf:Description>
 
-<!-- シエルリント女学薗 -->
-
-<rdf:Description rdf:about="Schwarzes_Kreuz_Medic">
-  <schema:name xml:lang="ja">黒十字マディック隊</schema:name>
-  <!-- <schema:name xml:lang="en">Schwarzes Kreuz Medic</schema:name> -->
-  <!-- <schema:alternateName xml:lang="ja"></schema:alternateName> -->
-  <!-- <schema:alternateName xml:lang="en"></schema:alternateName> -->
-  <lily:disbanded rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</lily:disbanded>
-  <!-- <lily:legionGrade rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:legionGrade> -->
-  <!-- <lily:numberOfMembers rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:numberOfMembers> -->
-  <schema:member rdf:resource="Michikawa_Miaki"/>
-  <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Legion"/>
-</rdf:Description>
-
 </rdf:RDF>

--- a/RDFs/legion.rdf
+++ b/RDFs/legion.rdf
@@ -795,4 +795,18 @@
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Legion"/>
 </rdf:Description>
 
+<!-- シエルリント女学薗 -->
+
+<rdf:Description rdf:about="Schwarzes_Kreuz_Medic">
+  <schema:name xml:lang="ja">黒十字マディック隊</schema:name>
+  <!-- <schema:name xml:lang="en">Schwarzes Kreuz Medic</schema:name> -->
+  <!-- <schema:alternateName xml:lang="ja"></schema:alternateName> -->
+  <!-- <schema:alternateName xml:lang="en"></schema:alternateName> -->
+  <lily:disbanded rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</lily:disbanded>
+  <!-- <lily:legionGrade rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></lily:legionGrade> -->
+  <!-- <lily:numberOfMembers rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:numberOfMembers> -->
+  <schema:member rdf:resource="Michikawa_Miaki"/>
+  <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Legion"/>
+</rdf:Description>
+
 </rdf:RDF>

--- a/RDFs/taskforce.rdf
+++ b/RDFs/taskforce.rdf
@@ -108,4 +108,17 @@
   <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Taskforce"/>
 </rdf:Description>
 
+<!-- シエルリント女学薗 -->
+
+<rdf:Description rdf:about="Schwarzes_Kreuz_Madec">
+  <schema:name xml:lang="ja">黒十字マディック隊</schema:name>
+  <schema:name xml:lang="en">Schwarzes Kreuz Madec Corps</schema:name>
+  <!-- <schema:alternateName xml:lang="ja"></schema:alternateName> -->
+  <!-- <schema:alternateName xml:lang="en"></schema:alternateName> -->
+  <lily:disbanded rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</lily:disbanded>
+  <!-- <lily:numberOfMembers rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"></lily:numberOfMembers> -->
+  <schema:member rdf:resource="Michikawa_Miaki"/>
+  <rdf:type rdf:resource="https://lily.fvhp.net/rdf/IRIs/lily_schema.ttl#Taskforce"/>
+</rdf:Description>
+
 </rdf:RDF>


### PR DESCRIPTION
### 概要

道川深顯、黒十字マディック隊の追加

### 情報源

- アサルトリリィ LastBullet イベントストーリー「罪なき少女達のスティグマ」
- アサルトリリィ LastBullet イベントストーリー「夜闇を駆けるエージェント」

### チェック項目

この変更は
- [x] 新しいクラスやプロパティ定義を追加する (11月13日変更)
- [ ] 既存のデータ構造やデータ規則の破壊的な変更を含む
- [ ] 既存のRDF制約に違反しており、制約を緩和する必要がある

### 特記事項1

要望ツイート

https://twitter.com/nagatsuki_yuu/status/1450739847245615105

### 特記事項2

疑問：「黒十字マディック隊」のスキーマ名は"Schwarzes_Kreuz_Medic"でいいのか？
- 「黒十字」はおそらくドイツ語由来だろうという推測
- 「マディック」の公式なスペルも不明、衛生兵やインターン生を意味するメディック(Medic)が由来だろうという推測
- 「隊」をどう訳すのか
- 英語名(lang="en")はドイツ語の"Schwarzes_Kreuz"から英語の"Black Cross"に直すべきか？（よくわからないので現状コメントアウト）
- 正直なところ内部識別子という本質的でない部分で悩みたくない
- ユニークな識別子であれば何でもいいならそのまま日本語でとか