### PR TITLE
一柳隊のalternateName指定の修正

### DIFF
--- a/RDFs/legion.ttl
+++ b/RDFs/legion.ttl
@@ -7,7 +7,7 @@
 
 <Radgrid>
     schema:name "ラーズグリーズ"@ja, "Radgrid"@en ;
-    schema:alternateName "一柳隊"@ja, "Hitotsuyanagi-Tai";
+    schema:alternateName "一柳隊"@ja, "Hitotsuyanagi-Tai"@en;
     lily:disbanded false ;
     # lily:legionGrade ""^^xsd:string ;
     lily:numberOfMembers "9"^^xsd:integer ;


### PR DESCRIPTION
### 概要

LGラーズグリーズ(一柳隊) の `schema:alternateName` の英語綴りに言語コード指定がなかったものを修正しています

### チェック項目

この変更は
- [ ] 新しいクラスやプロパティ定義を追加する
- [ ] 既存のデータ構造やデータ規則の破壊的な変更を含む
- [ ] 既存のRDF制約に違反しており、制約を緩和する必要がある
