### PR TITLE
グングニルのプロパティ宣言を修正

### DIFF
--- a/RDFs/charm.ttl
+++ b/RDFs/charm.ttl
@@ -114,7 +114,7 @@
         <Wang_Yujia>,
         <Kosaka_Anastasiya_Ryoko>,
         <Yoshizaka_Nagisa> ;
-    lily::hasVariant <Gungnir_Carbin> ;
+    lily:hasVariant <Gungnir_Carbin> ;
     # lily:additionalInformation ""@ja ;
     a lily:Charm ;
 .


### PR DESCRIPTION
### 概要

グングニルの「CHARMなどの派生先を表すプロパティ」を宣言する部分で、
接頭辞とローカル名をつなぐコロンがダブルコロンとなっていたため、
シングルコロンへ修正。

### チェック項目

この変更は
- [ ] 新しいクラスやプロパティ定義を追加する
- [ ] 既存のデータ構造やデータ規則の破壊的な変更を含む
- [ ] 既存のRDF制約に違反しており、制約を緩和する必要がある